### PR TITLE
Adds optimization of CiC painting which prevents ops runing on CPU

### DIFF
--- a/diffhod/utils.py
+++ b/diffhod/utils.py
@@ -48,7 +48,7 @@ def cic_paint(mesh, part, weight=None, name="CiCPaint"):
     batch_idx = tf.range(0, batch_size)
     batch_idx = tf.reshape(batch_idx, (batch_size, 1, 1, 1))
     b = tf.tile(batch_idx, [1] + list(neighboor_coords.get_shape()[1:-1]) + [1])
-    b = tf.cast(b,tf.float32)
+    b = tf.cast(b, tf.float32)
     neighboor_coords = tf.concat([b, neighboor_coords], axis=-1)
 
     neighboor_coords = tf.cast(neighboor_coords, tf.int32)

--- a/diffhod/utils.py
+++ b/diffhod/utils.py
@@ -44,9 +44,6 @@ def cic_paint(mesh, part, weight=None, name="CiCPaint"):
     if weight is not None:
       kernel = tf.multiply(tf.expand_dims(weight, axis=-1), kernel)
 
-    
-    neighboor_coords = tf.math.mod(neighboor_coords, nc)
-
     # Adding batch dimension to the neighboor coordinates
     batch_idx = tf.range(0, batch_size)
     batch_idx = tf.reshape(batch_idx, (batch_size, 1, 1, 1))

--- a/diffhod/utils.py
+++ b/diffhod/utils.py
@@ -44,15 +44,17 @@ def cic_paint(mesh, part, weight=None, name="CiCPaint"):
     if weight is not None:
       kernel = tf.multiply(tf.expand_dims(weight, axis=-1), kernel)
 
-    neighboor_coords = tf.cast(neighboor_coords, tf.int32)
+    
     neighboor_coords = tf.math.mod(neighboor_coords, nc)
 
     # Adding batch dimension to the neighboor coordinates
     batch_idx = tf.range(0, batch_size)
     batch_idx = tf.reshape(batch_idx, (batch_size, 1, 1, 1))
     b = tf.tile(batch_idx, [1] + list(neighboor_coords.get_shape()[1:-1]) + [1])
+    b = tf.cast(b,tf.float32)
     neighboor_coords = tf.concat([b, neighboor_coords], axis=-1)
 
+    neighboor_coords = tf.cast(neighboor_coords, tf.int32)
     update = tf.scatter_nd(
         tf.reshape(neighboor_coords, (-1, 8, 4)), tf.reshape(kernel, (-1, 8)),
         [batch_size, nx, ny, nz])

--- a/nb/Optimized_HOD_HMC_sampling.ipynb
+++ b/nb/Optimized_HOD_HMC_sampling.ipynb
@@ -1,0 +1,823 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Optimized_HOD_HMC_sampling.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "authorship_tag": "ABX9TyPhrNVdPgYZoDLxFcD+gJde",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/DifferentiableUniverseInitiative/DHOD/blob/u%2FEiffL%2Foptimization/nb/Optimized_HOD_HMC_sampling.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "A-G7iEAnRFFD"
+      },
+      "source": [
+        "# Sampling HOD parameters by Hamiltonian Monte-Carlo\n",
+        "\n",
+        "Authors:\n",
+        " - [@bhorowitz](https://github.com/bhorowitz) (Ben Horowitz)\n",
+        " - [@EiffL](https://github.com/EiffL) (Francois Lanusse)\n",
+        "\n",
+        "\n",
+        "This notebook demonstrate sampling HOD parameters using HMC over a stochastically sampled galaxy catalogs.\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "I0oMCwV4RnSQ"
+      },
+      "source": [
+        "## Setup\n",
+        "\n",
+        "Here we quickly install our dependencies, and download the reference halotools \n",
+        "catalog from the Bolshoi simulation. This takes under a minute."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "w4oAbz0FRBBB"
+      },
+      "source": [
+        "!pip install --quiet -i https://test.pypi.org/simple/ halotools\n",
+        "!pip install --quiet corner\n",
+        "!pip install --quiet git+https://github.com/DifferentiableUniverseInitiative/DHOD.git@u/EiffL/optimization"
+      ],
+      "execution_count": 23,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "mjxUSvG7R_y1"
+      },
+      "source": [
+        "!download_initial_halocat.py"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8pqOl6nNaWnH"
+      },
+      "source": [
+        ""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "HJRyg0qcXUDg",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "b0f04b70-eb71-4b84-e1b1-594f05f0825a"
+      },
+      "source": [
+        "%pylab inline\n",
+        "from halotools.sim_manager import CachedHaloCatalog\n",
+        "from halotools.empirical_models import PrebuiltHodModelFactory\n",
+        "from halotools.mock_observables.two_point_clustering import tpcf\n",
+        "from halotools.mock_observables import return_xyz_formatted_array"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Populating the interactive namespace from numpy and matplotlib\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kUfaj2PkXcPU"
+      },
+      "source": [
+        "import tensorflow as tf\n",
+        "import edward2 as ed\n",
+        "from diffhod.components import Zheng07Cens, Zheng07Sats, NFWProfile\n",
+        "from diffhod.utils import cic_paint\n",
+        "from diffhod.mock_observables.pk import Power_Spectrum"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "HcRwN9VIXr98"
+      },
+      "source": [
+        "# A few hyper parameters\n",
+        "temperature=0.02\n",
+        "batch_size=2\n",
+        "box_size = 128.\n",
+        "\n",
+        "fid_params = tf.convert_to_tensor([12.02, 0.26, 11.38, 13.31, 1.06])"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 334
+        },
+        "id": "q26Jzod9SQST",
+        "outputId": "9cb06e46-5339-4687-fec4-04b1b3399b76"
+      },
+      "source": [
+        "# Load a reference halo catalog\n",
+        "halocat = CachedHaloCatalog(simname = 'bolshoi', redshift=0.) \n",
+        "\n",
+        "# Removing subhalos, and restricting the size of the catalog\n",
+        "halo_table = halocat.halo_table\n",
+        "halo_table = halo_table[halo_table['halo_pid'] == -1]\n",
+        "halo_table = halo_table[halo_table['halo_x'] < box_size]\n",
+        "halo_table = halo_table[halo_table['halo_y'] < box_size]\n",
+        "halo_table = halo_table[halo_table['halo_z'] < box_size]\n",
+        "print(\"Total size of halo catalog\", len(halo_table))\n",
+        "\n",
+        "# Split the catalog into low and high mass halo\n",
+        "low_mass_table = halo_table[np.log10(halo_table['halo_mvir']) < 13.75]\n",
+        "high_mass_table = halo_table[np.log10(halo_table['halo_mvir']) >= 13.75]\n",
+        "\n",
+        "# Convert table to tensors\n",
+        "tf_halocat_low = {k: tf.convert_to_tensor(low_mass_table[k], dtype=tf.float32) for k in halo_table.colnames}\n",
+        "tf_halocat_high = {k: tf.convert_to_tensor(high_mass_table[k], dtype=tf.float32) for k in halo_table.colnames}\n",
+        "\n",
+        "hist(log10(low_mass_table['halo_mvir']),32, range=[10,15]);\n",
+        "hist(log10(high_mass_table['halo_mvir']),32, range=[10,15]);\n",
+        "yscale('log')\n",
+        "xlabel('halo_mvir');\n",
+        "print(\"Size of low mass halo catalog\", len(low_mass_table))\n",
+        "print(\"Size of high mass halo catalog\", len(high_mass_table));"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Total size of halo catalog 139905\n",
+            "Size of low mass halo catalog 139797\n",
+            "Size of high mass halo catalog 108\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEHCAYAAABV4gY/AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAO1klEQVR4nO3df6zd9V3H8edrTJaJyHR0m4PW4m5D7MiGyxn7w6j84Y+y0RU3RJrFgBJqzepfLg6cP5qoCWYxZDNkpBMsSzZYh3O2owuQGYZ/gOEyQeg6tKnMtjJaxsREzQjj7R/3oIfbe+Hce8/3fns/9/lIyL3ne875ft/flL748P5+vp9vqgpJUlte03cBkqTJM9wlqUGGuyQ1yHCXpAYZ7pLUoNf2XQDA2WefXevXr++7DElaUR5++OFnqmrNXO/1Gu5JNgObp6ammJ6e7rMUSVpxknxrvvd6bctU1b6q2nbWWWf1WYYkNceeuyQ1yHCXpAYZ7pLUoF7DPcnmJLuee+65PsuQpOZ4QVWSGmRbRpIaZLhLUoNOiTtUW7T+urvG+tyTN7yv40okrUaO3CWpQc6WkaQGOVtGkhpkW0aSGmS4S1KDnC3Ts3Fm1TijRtJCOXKXpAYZ7pLUIMNdkhpkuEtSg7yJSZIa5E1MktQgp0KuAC5CJmmh7LlLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBjkVsiGuMCnpJY7cJalBnYR7kjOSTCe5tIv9S5Je2VjhnuTWJMeTPD5r+6YkTyQ5lOS6kbc+CuyZZKGSpPGNO3LfDWwa3ZDkNOAm4BJgI7A1ycYkvwB8Azg+wTolSQsw1gXVqro/yfpZmy8CDlXVYYAkdwBbgB8CzmAm8P8nyf6qenFiFZ8Cxl3rRZL6spTZMucAR0ZeHwXeU1U7AJJcDTwzX7An2QZsA1i3bt0SytBCuAiZtDp0NlumqnZX1Zdf4f1dVTWoqsGaNWu6KkOSVqWlhPsxYO3I63OH28bmwzokqRtLCfeHgA1JzktyOnAlsHchO/BhHZLUjXGnQt4OPACcn+Rokmuq6gVgB3A3cBDYU1UHFnJwR+6S1I1xZ8tsnWf7fmD/Yg9eVfuAfYPB4NrF7kOSdDKXH5CkBvW6cFiSzcDmqampPsvQHFyETFrZeh25e0FVkrphW0aSGmS4S1KDeg13p0JKUjfsuUtSg3zMnhbNRcikU5dtGUlqkG0ZSWqQs2UkqUGGuyQ1yHCXpAZ5QVWSGtTrVEiX/F0dXIRMWn62ZSSpQYa7JDXIcJekBhnuktQgZ8tIUoNcfkCSGuSqkDoluMKkNFn23CWpQYa7JDXItsyIcVsDknSqc+QuSQ0y3CWpQbZltKK4CJk0Hm9ikqQGeROTJDXInrskNchwl6QGGe6S1CDDXZIa5FRINcdFyCRH7pLUJMNdkhpkuEtSgwx3SWrQxMM9yU8muTnJnUl+a9L7lyS9urFmyyS5FbgUOF5VF4xs3wR8AjgN+MuquqGqDgLbk7wG+AzwqcmXvXCu1S5pNRl35L4b2DS6IclpwE3AJcBGYGuSjcP33g/cBeyfWKWSpLGNNXKvqvuTrJ+1+SLgUFUdBkhyB7AF+EZV7QX2JrkL+NzkypUmx+WD1bKl3MR0DnBk5PVR4D1JLgY+ALyOVxi5J9kGbANYt27dEsqQJM028TtUq+o+4L4xPrcL2AUwGAxq0nVI0mq2lNkyx4C1I6/PHW4bmw/rkKRuLCXcHwI2JDkvyenAlcDehezAh3VIUjfGCvcktwMPAOcnOZrkmqp6AdgB3A0cBPZU1YGFHNyRuyR1I1X9t7sHg0FNT093egznuatLzqpRH5I8XFWDud5z+QFJalCv4W5bRpK60Wu4e0FVkrphW0aSGmRbRpIa1OszVKtqH7BvMBhc22cd0lK5To1ONbZlJKlBvY7cJ8H565J0MnvuktQgp0JKUoPsuUtSgwx3SWqQ4S5JDep1tkySzcDmqampPsuQlsW4M7ucD69J8IKqJDXItowkNchwl6QGGe6S1CDDXZIa5PIDktQgl/yVTjEuH6xJsC0jSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDvIlJkhrkkr+S1KBe71CVtDg++EOvxp67JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapBTIaWGOWVy9XLkLkkN6mTknuQy4H3ADwO3VNU9XRxHkjS3sUfuSW5NcjzJ47O2b0ryRJJDSa4DqKovVdW1wHbgVydbsiTp1SykLbMb2DS6IclpwE3AJcBGYGuSjSMf+f3h+5KkZTR2uFfV/cCzszZfBByqqsNV9TxwB7AlM/4M+EpVfX1y5UqSxrHUC6rnAEdGXh8dbvtt4OeBy5Nsn+uLSbYlmU4yfeLEiSWWIUka1ckF1ar6JPDJV/nMLmAXwGAwqC7qkDSecaZMOl1yZVnqyP0YsHbk9bnDbWPxYR2S1I2lhvtDwIYk5yU5HbgS2Dvul31YhyR1YyFTIW8HHgDOT3I0yTVV9QKwA7gbOAjsqaoDC9inI3dJ6sDYPfeq2jrP9v3A/sUcvKr2AfsGg8G1i/m+JGluLj8gSQ3qNdxty0hSN3oNdy+oSlI3bMtIUoN6Xc89yWZg89TUVJ9lSBqDa8OvLLZlJKlBtmUkqUGGuyQ1yKmQktQge+6S1CDbMpLUIMNdkhpkuEtSg7ygKkkN6vUOVZf8lRq0c4wJEjsd0HXNtowkNchwl6QGGe6S1KBee+6SVqlx+vJgb34JnC0jSQ1y+QFJapA9d0lqkOEuSQ0y3CWpQYa7JDXIcJekBjnPXdKpy3VqFs2RuyQ1yJuYJKlB3sQkSQ2yLSNJDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ2aeLgn+YkktyS5c9L7liSNZ6xwT3JrkuNJHp+1fVOSJ5IcSnIdQFUdrqpruihWkjSecUfuu4FNoxuSnAbcBFwCbAS2Jtk40eokSYsyVrhX1f3As7M2XwQcGo7UnwfuALaMe+Ak25JMJ5k+ceLE2AVLkl7dUnru5wBHRl4fBc5J8sYkNwM/leT6+b5cVbuqalBVgzVr1iyhDEnSbBN/ElNVfQfYPun9SpLGt5SR+zFg7cjrc4fbxubDOiSpG0sJ94eADUnOS3I6cCWwdyE78GEdktSNcadC3g48AJyf5GiSa6rqBWAHcDdwENhTVQcWcnBH7pLUjbF67lW1dZ7t+4H9iz14Ve0D9g0Gg2sXuw9J0slcfkCSGjTx2TILkWQzsHlqaqrPMiStBjvHuLa3s50Wca8jdy+oSlI3bMtIUoNsy0ha2cZpt6xCtmUkqUG2ZSSpQYa7JDWo13D3DlVJ6oY9d0lqkG0ZSWqQ4S5JDTLcJalBXlCVpAZ5QVWSGmRbRpIaZLhLUoMMd0lqkOEuSQ1yyV9Jesm4ywevgCc2OVtGkhpkW0aSGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAa55K8kNShV1XcNJDkBfGuRXz8beGaC5awEnvPq4DmvDks55x+vqjVzvXFKhPtSJJmuqkHfdSwnz3l18JxXh67O2Z67JDXIcJekBrUQ7rv6LqAHnvPq4DmvDp2c84rvuUuSTtbCyF2SNIvhLkkNWlHhnuTWJMeTPD6y7UeT3JvkX4Y/f6TPGidtnnP+lSQHkryYpLlpY/Oc88eTfDPJPyX5myRv6LPGSZvnnP94eL6PJLknyVv7rHHS5jrnkfd+J0klObuP2rowz5/xziTHhn/GjyR576SOt6LCHdgNbJq17Trgq1W1Afjq8HVLdnPyOT8OfAC4f9mrWR67Ofmc7wUuqKp3AP8MXL/cRXVsNyef88er6h1VdSHwZeAPl72qbu3m5HMmyVrgF4F/W+6COrabOc4XuLGqLhz+s39SB1tR4V5V9wPPztq8Bbht+PttwGXLWlTH5jrnqjpYVU/0VFLn5jnne6rqheHLB4Fzl72wDs1zzv858vIMoKnZD/P8fQa4EfhdVs/5dmJFhfs83lxVTw1//zbw5j6L0bL4DeArfRexHJL8aZIjwIdob+R+kiRbgGNV9WjftSyjHcP2262TbCu3EO7/p2bmdTb1X3u9XJKPAS8An+27luVQVR+rqrXMnO+OvuvpUpIfBH6PVfAfsRGfAt4GXAg8Bfz5pHbcQrg/neTHAIY/j/dcjzqS5GrgUuBDtfpu0Pgs8MG+i+jY24DzgEeTPMlM6+3rSd7Sa1Udqqqnq+r7VfUi8Gngokntu4Vw3wtcNfz9KuBve6xFHUmyiZk+7Pur6r/7rmc5JNkw8nIL8M2+alkOVfVYVb2pqtZX1XrgKPCuqvp2z6V15qWB6dAvMzNZYjL7XkkDoCS3Axczs0Tm08AfAV8C9gDrmFk2+IqqWraLFl2b55yfBf4CWAP8B/BIVf1SXzVO2jznfD3wOuA7w489WFXbeymwA/Oc83uB84EXmfl3e3tVHeurxkmb65yr6paR958EBlXVxBLA8/wZX8xMS6aAJ4HfHLmGuLTjraRwlySNp4W2jCRpFsNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrtWvCTr51o29hU+vzPJR7qsaY5jvjXJnct5TK1uhru0DKrq36vq8tnbk7y2j3rUPsNdrTgtyaeHDzG5J8nrk1yb5KEkjyb56+HCVC+T5MIkD448BGTeVfmS3JfkxiTTSQ4meXeSLw4fFPMnw8/ckOTDI9/ZmeQjo/93keTqJHuT/B0zzyCQJs5wVys2ADdV1duZWZLhg8AXq+rdVfVO4CBwzRzf+wzw0eFDQB5j5pbwV/J8VQ2Am5lZx+jDwAXA1UneCHweuGLk81cMt832LuDyqvq5cU9QWgjDXa3416p6ZPj7w8B64IIkf5/kMWbWQ3/76BeSnAW8oaq+Ntx0G/Czr3KcvcOfjwEHquqpqvoecBhYW1X/CLxp2GN/J/Ddqjoyx37ubWkNJJ167PepFd8b+f37wOuZeazZZVX16HC54IsneJwXZx3zRf7/79MXgMuBtzD3qB3gvyZQizQvR+5q2ZnAU0l+gJmR+8tU1XPAd5P8zHDTrwFfm/25Rfg8cCUzAf+FCexPWjBH7mrZHwD/AJwY/jxzjs9cBdw8vNh6GPj1pR60qg4kOZOZx8VNZPlWaaFc8leSGmRbRpIaZFtGmiXJTcBPz9r8iar6qz7qkRbDtowkNci2jCQ1yHCXpAYZ7pLUIMNdkhr0v6ugzSemEHNKAAAAAElFTkSuQmCC\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "d9AtT-UpXRcx"
+      },
+      "source": [
+        "# Here is how we define the same model in\n",
+        "def hod(halo_cat, \n",
+        "        logMmin=12.02, sigma_logM=0.26, logM0=11.38, logM1=13.31, alpha=1.06,\n",
+        "        max_sat=20):\n",
+        "  \n",
+        "  ### Occupation model ###\n",
+        "  n_cen = Zheng07Cens(halo_cat['halo_mvir'],\n",
+        "                      sigma_logM=sigma_logM,\n",
+        "                      logMmin=logMmin,\n",
+        "                      temperature=temperature)\n",
+        "  \n",
+        "  n_sat = Zheng07Sats(halo_cat['halo_mvir'],\n",
+        "                      n_cen,\n",
+        "                      logM0=logM0,\n",
+        "                      logM1=logM1,\n",
+        "                      alpha=alpha,\n",
+        "                      sample_shape=(max_sat,),\n",
+        "                      temperature=temperature)\n",
+        "  \n",
+        "  ### Phase Space model ###\n",
+        "  # Centrals are just located at center of halo\n",
+        "  pos_cen = ed.Deterministic(tf.stack([halo_cat['halo_x'],\n",
+        "                                       halo_cat['halo_y'],\n",
+        "                                       halo_cat['halo_z']], axis=-1))\n",
+        "\n",
+        "  # Satellites follow an NFW profile centered on halos\n",
+        "  pos_sat = NFWProfile(pos=pos_cen,\n",
+        "                       concentration=halo_cat['halo_nfw_conc'],\n",
+        "                       Rvir=halo_cat['halo_rvir'],\n",
+        "                       sample_shape=(max_sat, batch_size))\n",
+        "  \n",
+        "  return {'pos_cen':pos_cen,'n_cen':n_cen, 'pos_sat':pos_sat, 'n_sat':n_sat}"
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "P1vs2DVgYB-O"
+      },
+      "source": [
+        "def paint_galaxies(gal_cat, nc=128, rho=None):\n",
+        "  \"\"\" Function that paints galaxies on the field\n",
+        "  \"\"\"\n",
+        "  # Take centrals and rescale them to the boxsize\n",
+        "  bs = gal_cat['n_sat'].shape[1]\n",
+        "\n",
+        "  # Convert to mesh pixel coordinate\n",
+        "  sample1 = gal_cat['pos_cen'] / box_size * nc\n",
+        "  weights1 = gal_cat['n_cen']\n",
+        "  sample1_r = tf.tile(tf.expand_dims(sample1,0),[bs,1,1])\n",
+        "\n",
+        "  # Take sats and rescale them to the boxize\n",
+        "  sample2 = gal_cat['pos_sat'] / box_size * nc\n",
+        "  weights2 = gal_cat['n_sat']\n",
+        "  # Swapping sample dimension and batch dimension\n",
+        "  sample2 = tf.transpose(sample2, [1,0,2,3])\n",
+        "  weights2 = tf.transpose(weights2, [1,0,2])\n",
+        "  # Reshaping\n",
+        "  sample2 = tf.reshape(sample2, [bs, -1, 3])\n",
+        "  weights2 = tf.reshape(weights2, [bs, -1])\n",
+        "  \n",
+        "  if rho is None:\n",
+        "    rho = tf.zeros((bs, nc, nc, nc))\n",
+        "\n",
+        "  rho = cic_paint(rho,sample1_r, weights1)\n",
+        "  rho = cic_paint(rho, sample2, weights2)\n",
+        "  return rho"
+      ],
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-lnkNs_DqAL7"
+      },
+      "source": [
+        "# Let's now build a function that returns a sampled power spectrum\n",
+        "PS = Power_Spectrum(shape=np.array([box_size, box_size, box_size]).astype('int32'), \n",
+        "               boxsize=np.array([box_size, box_size, box_size]),\n",
+        "               kmin=0.1,dk=.05)\n",
+        "\n",
+        "@tf.function\n",
+        "def get_pk(logMmin=12.02, sigma_logM=0.26, logM0=11.38, logM1=13.31, alpha=1.06,\n",
+        "           max_sat_low=20, max_sat_high=100):\n",
+        "  \"\"\" This function samples the catalogs, paint the galaxies, and compute the \n",
+        "  power spectrum\n",
+        "  \"\"\"\n",
+        "  # Sample and paint galaxies low mass halos\n",
+        "  rho = paint_galaxies(hod(tf_halocat_low, logMmin, sigma_logM, logM0, logM1, alpha,\n",
+        "                           max_sat=max_sat_low))\n",
+        "  \n",
+        "  # Add galaxies from high mass halos\n",
+        "  rho = paint_galaxies(hod(halo_cat_high, logMmin, sigma_logM, logM0, logM1, alpha,\n",
+        "                           max_sat=max_sat_high),\n",
+        "                       rho=rho)\n",
+        "  \n",
+        "  # Compute power spectrum of resulting field\n",
+        "  k, pk = PS.pk_tf(rho)\n",
+        "  return k, pk"
+      ],
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "4z05F52Eptzz",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "a8d968bc-2fc6-4de2-f5bf-6611257fd748"
+      },
+      "source": [
+        "# Let's just compute a diagonal cov (takes a while...)\n",
+        "import time\n",
+        "start_time = time.time()\n",
+        "samps = []\n",
+        "for i in range(50):\n",
+        "  k, pk = get_pk(logMmin=12.02*tf.ones([batch_size]),\n",
+        "                sigma_logM=0.26*tf.ones([batch_size]), \n",
+        "                logM0=11.38*tf.ones([batch_size]), \n",
+        "                logM1=13.31*tf.ones([batch_size]), \n",
+        "                alpha=1.06*tf.ones([batch_size]))\n",
+        "  samps.append(pk)\n",
+        "end_time = time.time()- start_time\n",
+        "print(end_time)"
+      ],
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "20.186707735061646\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "jUr5-ETrrf_2"
+      },
+      "source": [
+        "samps = np.stack(samps, axis=0).reshape(100,-1)\n",
+        "diag_std = samps.std(axis=0)\n",
+        "mean = samps.mean(axis=0)"
+      ],
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 287
+        },
+        "id": "RiTSCIVnswKc",
+        "outputId": "6eee83e3-a30f-4c9a-92e9-59ca16c9a82b"
+      },
+      "source": [
+        "loglog(diag_std)\n",
+        "loglog(mean)"
+      ],
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[<matplotlib.lines.Line2D at 0x7fb05616e510>]"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 12
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD8CAYAAAB0IB+mAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXxV9Z3/8df3ZiX7nkBCEgj7IlsAsSpuWFxQq7ajdOhYF7SO/qa2nWk79td2ftOOnXamu5ZS12rVWrUtLlWriNqqQILs+xZIWAJkIwlZ7/f3xzchAUFCtnNv7vv5eJxHcs8999xP8Po5536+m7HWIiIiA5/P6wBERKR/KOGLiIQIJXwRkRChhC8iEiKU8EVEQoQSvohIiAj3OoBPkpaWZvPz870OQ0QkqBQXFx+21qafvD+gE35+fj5FRUVehyEiElSMMSWn2q+SjohIiOi3hG+MGW6MecQY83x/vaeIiHToUsI3xjxqjCk3xqw/af9cY8wWY8x2Y8w3Pukc1tqd1trbehKsiIh0X1dr+I8DvwR+277DGBMGPAjMAUqBlcaYJUAY8MBJr7/VWlve42hFRKTbupTwrbXvGmPyT9o9A9hurd0JYIx5FrjWWvsAcHV3AzLGLAQWAuTm5nb3NCIicpKe1PCzgb2dHpe27TslY0yqMWYRMMUY883THWetXWytLbTWFqanf6xXkYiIdFO/dcu01h4B7uqv9xMRkRP15A6/DBja6XFO274eM8bMM8Ysrq6u7o3TiYgIPUv4K4GRxphhxphI4CZgSW8EZa19yVq7MDExsTdOJyIidL1b5jPAB8BoY0ypMeY2a20LcA/wOrAJeM5au6HvQhURkZ7oai+dm0+z/1Xg1V6NCFfSAeaNz0uD937cvZNExUPaSEgbDfFZYEyvxigiEmxMIK9pWzgkzBYtjOv5iaISOpJ/+ij3M20UJOdDWEBPJyQictaMMcXW2sKT9wd2ths8Ge7/e/dee6wSDm9126Et7ufOt2HN0x3HhEVCSoG7GKSPbrsQjHRbZGzv/A0iIgEiIBN+e0lnxIgREBHdvZNEDIaEwTB89on7G6rh8HY4vKXjQlC+ETa/Ara147jE3LZvA21betu3gti0bv9dIiJeCuySTmGh7bfpkVsaoWJn2zeCrR0XhCPbobm+47hBKR3Jv/OFIHEo+DT5qIh4LzhLOv0pPAoyxrqtM78fako7LgLtF4TNL0P9kU6vHwRpIzraB9rbClIL3LlFRDymhH8mPh8k5bpt5GUnPld3pK2dYEvbBWErlK6A9S8Abd+cjM81Dh9vMB7V8Xu0xhmISP8JyIR/Qg0/kMWmQuwsyJt14v6melcK6txgfHgr7HgLWps6jovL+niDcfpoiB+sbqQi0utUw+9PrS1QVXLihaD9Z2NNx3GR8Z0uBG3tBJkT3LcMXQhE5AxUww8EYeGupp9aAKOv6NhvLdQePPHbwKEtsHMZrHmm47joJBg8qdM2GVKGq7FYRLpECT8QGONGA8dnnaIbaY27ABxYC/vXuG35oo7SUGQcZJ1z4oUgbZQGlInIxygrBLroBMgpdFu7libXUNx+Adi/BlY90dF9NDzalYA6XwQyxqq3kEiIC8gafqdG2zu2bdvmdTjBwd/qGoo7XwT2r+loG/BFuKTfuRyUOR4iY7yNW0R63elq+AGZ8NsNuEbb/ub3Q9Xuj18E2scPGJ/rHTR4EgxuKwtlTVR3UZEgp0bbUOTzuUbdlOEw/jNun7VQU9bpArAWdr0La5/teF3K8I5vAkOmwJCprrQkIkFNCT/UGAOJOW4bc1XH/tpyl/z3r3YXgrJVsOGP7S9yDcHZ0yB7qvuZOQHCIz35E0Ske5TwxYnLcCOJO48mrq+AfR+55F9WDNv/2jHbaFiUKwNlT+vYUoZrnIBIAFMNX7rOWqguhbIidwEoW+UuCO29g6KTOr4BtG9xGd7GLBKCgqrRVr10gkhri+siWlYMpUXuIlC+sWOq6cTcEy8CgydBVC8saiMipxVUCb+d7vCDVFOdaw8oK27biqBqj3vO+FxPoFFXwJgr3aAxlYFEepUSvnir9hDsW+W+Bex6F/YuB6xbR2D0FTD6Ssg/H8IivI5UJOgp4UtgqT0EW1+DLa/CjqXQ0gBRiTByjrvzHzFHXUFFukn98CWwxKXD1AVua6p36w1vfhW2/gXWP+9GBg+7wN35j74SErO9jlgk6OkOXwKLvxX2roAtr7gLQMUOt3/wZDduYPSVbkoI1f1FTkslHQk+1rqZQje/4ko/pSvd/qQ8mHQTFN7qZhgVkRMEVcJXt0w5paMHXcln4xJX9/eFuykjZt4FOdO8jk4kYARVwm+nO3w5rSM7YMVv4KOnoOkoZBe6xD/uWk35ICFPCV8GpsajsPoZWPFrNz10XBZMvw2m3aJRvhKylPBlYPP73SLxyxfB9jchLBIm3AAz73QzfoqEEHXLlIHN53N9+EfOgcPbYMViWP20WxN46ExX7hk7TwO7JKTpDl8GroZql/SX/xoqd7n1fyMGAcZ16zS+tt99bY9Np+fC3PrC593rZgEVCSIq6Ujo8rfCtr+6Uo9tBet3XT6tH7Btv9u239uea66HbW+AvwXGXw/nf9nNASQSBFTSkdDlC4PRc912No4egA8ehKJH3ejfkZfD+fdB3nl9E6dIH/N5HYBIwIrPgsv/E+5bD5d8y039/NgV8MinYctrbd8KRIKHEr7ImQxKhgv/Fb68Dq74kVsT+Jl/gF99CtY+B3WHlfwlKARkDV8jbSWgtTbD+hfgbz+BQ5vdvohYSMqF5Dw39UPn35PzIDrR25glpKjRVqS3+f2w+10o3+QWeKkscT+rSqCxptOBxnUNHXs1jLkaUoZ5FrKEBiV8kf5iLRyr7Ej+Bze62T8PrHPPZ02Esde4cQHpYzTzp/Q6JXwRr1Xuhk0vw6aXOlb8SilwC74MPRdypkN8ptdRygCghC8SSI4edHf9m16CXe+Bv9ntT8p1iT9nOuTMcN8GNBmcnCUlfJFA1dwAB9a6hV9KV7p1f2tK3XMmzHUPTRgC8YMhIRsS2n4Ou1ATxMkpaeCVSKCKiIahM9zWrmafS/7717jfa/a5xuHtb0FznTsmKsGND5h+uxtcJnIGusMXCSbWuh5AR7bDW//p1gIePAmu/glkaxEYcU53h6+BVyLBxBjXpz97Giz4I9z4mGsP+M2l8PJXXO8gkdNQSUckWBkDE66HEZfB2//lFoHZtARGftpdFDpvCUMg71MQpv/lQ5n+64sEu+gEuOIHMHk+/PXbrszTUA1NtSceFz8Epnwepixwo38l5KiGLzJQtba4en9DlRv0tepJN0U0QMHFMPULMGpu2xoBMpCol45IqAkLh5gUt6UMdwu8V+11C79/9BT84RY3B9Coy93I35GXQ1Sc11FLH9Idvkgo8rfCrnddzX/TS1B3CMKjYdhs1yA8ZAoMmax+/kEqIAZeGWOuA64CEoBHrLVvfNLxSvgi/cDfCns+gI1LYMdS1+WTtryQkA05hW7qh9xz3chfrQsc8Hpc0jHGPApcDZRbayd02j8X+BkQBjxsrf3B6c5hrf0T8CdjTDLwP8AnJnwR6Qe+MMg/320ADTVu5O++1bDvIzcCeOOf3XMRMTB4MmSOh6wJkDkRMsepHSBIdPkO3xhzIVAL/LY94RtjwoCtwBygFFgJ3IxL/g+cdIpbrbXlba/7X+B31tpVn/SeusMXCRDVZbD3Q9izHPavhoMbOnoBhUW5ZR8LLnFb5njNAOqxXinpGGPygZc7JfxZwHettZ9ue/xNAGvtycm+/fUG+AHwV2vtm2d6PyV8kQDl90P1HjiwHkred6WgQ5vcc3GZMPxiGHGp+xmX7m2sIaiveulkA3s7PS4FZn7C8fcClwGJxpgR1tpFpwh0IbAQIDc3t4fhiUif8PkgOd9tY692+6rLXOLf+TZsewPWPgvGB+M/A+d/xZWAxFP92i3TWvtz4OdnOGYxsBjcHX5/xCUivSAxG6YucJvfDwfWuKUgix5zP0d+Gmbe6XoCacSvJ3r6r14GDO30OKdtn4iEMp+vrWvnFLjgq7DiYVj+K3jqdYhJdf3+J94Iuee5Y6Vf9LSGH45rtL0Ul+hXAvOttRt6FJQWMRcZeJob3EjfDS/Clr9Ac70rCU3+R5h8MyTmeB3hgNHjRltjzDPARUAacBD4jrX2EWPMlcBPcT1zHrXWfr+3glajrcgA1VQHm1+BVb+F3e+5hV4Kvwizv6FG3l4QEAOvzpYSvkgIqNgF7/8Cih93/fzPuwdGzHHdOyOivY4uKAVVwldJRyQEHdoKb37XrfUL4At3i7tM/KzbYtM8DS+YBFXCb6c7fJEQVLXXjfDd95Hr5rl/tUv+Iy+H8dfD6LkQFe91lAFNCV9EgtPBjbD6d7D+RTi6z03yNvYat5bv0Bka1XsKQZXwVdIRkY/x+2Hvclj/PKx9zs31nzURzvsXN7hLffuPC6qE3053+CJySo21sO45+HARHN4CSXlw3r0w6WbN6Y8WMReRgSQqDgpvhbs/hJuehth0ePVr8OOx8Pr9ULPf6wgDkhK+iAQvnw/GXAW3vwm3vekadj/8Ffx8Mrz2TTh60OsIA0pAlnRUwxeRbqvYBe/+CNY8A74IN7dP4a2QPsbN/R8CVMMXkdByZAf8/aew+hnwN7tBXTnT3dw+w2d7HV2fUsIXkdBUsw92vgP717g1fGvKYPhFcPn3B+yUzUr4IiLNDVD0KLz7Q2iodn35L/gaxGd6HVmvUi8dEZGIaJh1N9y7ytX1Vz4MP50IL98HVXu8jq7PBWTCN8bMM8Ysrq6u9joUERmIYlLgqv+Fe4pg0k3w0VPw86nw8legvsLr6PqMSjoiItWl8N7/uumaYzPgM4uCumFXJR0RkdNJzIGrf+L680fGwm+vhaXfB3+r15H1KiV8EZF2Q6bAne/A5PmuYfeJa9xCLS2NXkfWK5TwRUQ6i4yF6x6Ca34JhzbBs/PhZ5Ngx9teR9ZjAZnw1WgrIp6bugC+ugXm/wGiEuDJ69x0DU11XkfWbQGZ8K21L1lrFyYmJnodioiEsrAIGHU5LFwG0++ADx+Ch2bBrve8jqxbAjLhi4gElMgYuOp/4JZX3Xw8T8yDN74FLU1eR3ZWlPBFRLoq/1Nw199g2i1u4fUnrg6qqZiV8EVEzkZkLMz7Kdz4GBxYDw+dCyt+ExRdOJXwRUS6Y8L1rrY/+By3+MpDs1wXzgCmhC8i0l3po+ALS+BzTwLWdeFc+n0I0BkMlPBFRHrCGBh3DXzpA5iywA3YeuF2qDvidWQfE5AJX/3wRSTohIXDNb+Ai++HjX+CB6fD9je9juoEAZnw1Q9fRIKSMTD73+DOdyEuE566EZb9AFpbvI4MCNCELyIS1DLHu4nYzvkcLHvAdd+sLfc6KiV8EZE+ERkL1y+G63/jlld8ZI5bZ9dDAT0fflLuGHvR1x/p3mtjIpiam0xhfjKThyYRExney9GJiHRRaRH87rOur/5nFsGYK/v07U43H35AZ8EwnyFhUES3Xruv6hjLthw6fp7xQxKYlpdMYV4KhfnJZCZE92aoIiKnl1Po+uw/9wV49ma3ju7F/+6maehHAX2H39MVr6rrm1m1p5KVuysoKqlkzd4qGlv8AAxNGURhXgrT8pKZnp/CyIw4fD7TW6GLiHxcc4MbpPXRk5B7npuGOWVYr7/N6e7wB3TCP1lTi58N+6opLnEXgeKSSg7XusmPEqLDmZqXTGFeMtPyUpg8NIlBkf179RWRELH6GfjL18EANz4KIy7r1dMr4Z+CtZaSI/UUlVRSXFLByt2VbC+vBSDcZxifnUhh+0UgP5mMeJWBRKSXVJa4kbnlG92C6oW39tqplfC7qLKuiVV7Kt1FYHclq0uraGorA+WlxpzQDjAiXWUgEemBxlp4/ouw7Q2YcANc+m1Izu/xaYMq4Rtj5gHzRowYcce2bds8jaWxpZX1ZTUUl1RQtLuS4pJKjtS5MlDioAim5SW3XQSSmTQ0iegIlYFE5Cy0tsA7/+2mW/aFwzU/c8m/B4Iq4bfz4g7/TKy17Dpcd/wbQFFJBTsOuSXPIsIM44ckMj3ftQMU5ieTFhflccQiEhSq9sILt8He5XDxt+DCr7mRu92ghN+HKuqaKC5xyb94dyVrS6tpanVloPzUGKblpTA9340JKEiPw3TzP6KIDHAtTbDkXlj7LNz0TLf76yvh9yNXBqpm5e7KtjJQBZX1zYAbEDYt1zUCT89PYWJ2ospAItLBWti0BMZeozv8YGStZefhOop3d3QH3XnYlYEiw3xMyE6gMD/leFtAqspAItIDSvgB5khtI8UllcfHBKwvqzleBhqeFuuSf1tbQEF6rMpAItJlSvgBrqG5lXVl1cdLQEUllVS1lYFSYiMpzEtmxrAUzh2eytjBCYSpO6iInEZQzqUTSqIjwpien8L0/BSgAL/fsvNwLUW7K1nZVgp6Y+NBAOKjwpmWn8zMYanMGObaASLDNfGpiHwyJfwA5fMZRmTEMyIjnptm5AKwv/oYK3ZVsHxXBSt2VbBsy2YAoiN8TM3tuABMydV4ABH5OJV0gtjh2kZWdroAbDpQg7VuPMCknCRmDk9hxrBUpuUlExela7tIqFANPwRUH2umaHfF8W8B68qqafXb49NDzxzmLgDT85NJion0OlwR6SNK+CGorrGFVXsqj18AVu918wIZA6Mz4zsuAMM0MZzIQKKELzQ0t7JmbxUrdlWwom08QH1TKwDD02PbLgDuIpCdNMjjaEWku9RLR4iOCGPm8FRmDk8FoLnVz/qyancB2FXBy2v388yKvQDkJA9ixrAULhiZxuxRGaTEqgQkEuz67Q7fGDMW+BcgDXjLWvurM71Gd/j9q9Vv2Xyg5vgFYPmuCirqmvAZmJKbzCVjMrh0bAajM+M1EEwkgPWopGOMeRS4Gii31k7otH8u8DMgDHjYWvuDLpzLB/zWWvuPZzpWCd9bfr9lXVk1b20u5+3N5awrqwZgSGI0l4zN4NIxmcwqSFUXUJEA09OEfyFQi0vUE9r2hQFbgTlAKbASuBmX/B846RS3WmvLjTHXAF8CnrTWPn2m91XCDywHaxp4e3M5SzeX87fth6lvaiU6wsenCtK4ZGwGl4zJYHCiav8iXutxo60xJh94uVPCnwV811r76bbH3wSw1p6c7E91rlestVed5rmFwEKA3NzcaSUlJV2KT/pXQ3Mry3dV8Pbmct7afJC9FccAGDs4gUvHZHDxmAwmD03SFBAiHuiLhH8jMNdae3vb4wXATGvtPad5/UXA9UAUsNZa++CZ3lN3+MHBWsv28lqWbi7nrc3lFJdU0uq3pMRGctHodC4Zk8GFo9JJiI7wOlSRkOB5Lx1r7TJgWX+9n/QfYwwjM+MZmRnPnbMLqK5v5p1th1i66SBLN5fz4qoywn2G6fkpXDo2gxnDUkiJjSQpJpLYyDA1AIv0k54k/DJgaKfHOW37eqzTmra9cTrpZ4kxEVwzaQjXTBpCS6uf1XureGtzOUs3lfO9VzadcGy4z5AUE0HioAiSYiJJjokgcVAkSTERJA2KcM/FRB7/PWlQJEmxEfq2ININPSnphOMabS/FJfqVwHxr7YbeCk4lnYGntLKeDftqqK5vpupYE1X1zVQdaz7+uLKumepjzVTVN1HXNijsVKbmJnHn7ALmjM3Ep3YCkRP0qKRjjHkGuAhIM8aUAt+x1j5ijLkHeB3XM+fR3kz2MjDlJMeQkxzTpWObWvxUH2um+lgTlfXN7uJQ38SB6gZ+X7SXO58spiA9ljtnF3Dd5GxNES1yBgE5tUKnks4d27Zt8zocCUAtrX5eWbefRe/sZNP+GrISornt/GHcPDNXM4NKyNNcOjIgWWt5d9thFi3bwQc7j5AQHc6CWXncct4w0uO1NrCEJiV8GfBW763i1+/s4LUNB4gI8/HZaTksvHA4eamxXocm0q+U8CVk7DxUy2/e28kLxWW0+P1cMXEwX5pdwITsRK9DE+kXQZXwVcOX3lBe08Ajf9/F0x/u4WhjC1Nzk8hJjnHdO9u6gHb83vZ4UCTx0eHq+SNBLagSfjvd4UtvqGlo5ncf7uGNjQeorHM9fmoamjndR99nIDkmktmj0rnrogJGZcb3b8AiPaSEL9JJq99Sc6yZynp3AahuGwNQWd9E9bFm9lc38Oq6/dQ3tXLZ2EzuvriAqbnJXoct0iVBlfBV0pFAUFnXxBMf7Obx93dTVd/MucNTuPuiEVwwMk3TQUhAC6qE3053+BII6hpbeGbFHh5+bxcHahqYmJ3Ily4q4NPjszQbqAQkJXyRHmpsaeVPH5Wx6J2d7Dpcx/D0WO66sIDpbZPBJUSH685fAoISvkgvafVbXlt/gIeWbWfDvprj+91EcJGkxEaQHBNJapzr/ZOZEM2VE7MYkaHGX+kfSvgivcxaS3FJJXsq6qmoa6KyvomKumYq65qoqG9yP9t+txYK85K5aUYuV00czKBILQspfSeoEr4abWUgOVzbyIurSnl2xV52Hq4jPjqc6yZnc9OMoYwfosFg0vuCKuG30x2+DCTWWpbvquDZFXt4df0Bmlr8nJOTyE3Tc7l60mDN8S+9RglfJIBU1Tfx4qoynl25h60Ha4kK93H5+CxumJrN+SPSCA/75KmeK+uaiIsOJ+IMx0loUsIXCUDWWtaUVvNCcSlL1uyj+lgzGfFRXDclmxum5jA6K56jDc2sK6tmzd5q1pZWsWZvFfuqG8hPjeE/rp3A7FHpXv8ZEmCU8EUCXGNLK29vLuf54jKWbSmnxW/JSojm4NGG49NA5KXGcE5OEmOy4nmhuJSdh+uYOz6L/ztvHNlJg7z9AyRgKOGLBJEjtY0sWbOP4pJKRmXGM2loEudkJ5IcG3n8mMaWVh5+bxe/WLoNg+HeS0dw+/nDtfKXBFfCVy8dka4rrazn/720kTc2HmR4eizfu3YC541I8zos8VBQJfx2usMX6bq3N5fznSUb2FNRzw1Tc7j/qrGkdPpGIKHjdAlf3/1EBoiLx2Twxn0XcvdFBfx5dRmX/fgdXlxVSiDf1En/UsIXGUCiI8L4t7ljePn/nE9eagxfeW4NCx5ZwdaDR6k+1kxdYwuNLa34/boIhCKVdEQGqFa/5enlJfz3a1uobWz52PODIsKYMy6T66dmc8HIdM38OYCcrqQT7kUwItL3wnyGBbPymTMui79uOkhjcyutfkuL39Lc6udgTQOvrjvAkjX7jvf9/+y0HEZqha8BS3f4IiGssaWVpZvKeWFVR9//qyYO5r45IzW7ZxALql466pYp0v+O1Dby+Pu7efRvuzjW3Mp1U7L58qWjGJIUzf7qBkorj1FaWU9EmI+xgxMYnh6rqR0CVFAl/Ha6wxfpf0dqG/n1uzt54v3dtLQ17raeopE3MszHyMw4Lh2byZdmF2jK5wCihC8iZ6W8poEnPyzBWhiaMoic5BhykgfR0Oxn0/4aNu6vYV1pNR/sPEJ20iC+PW8cl4/L1KpfAUAJX0T6xPKdR/j2nzew5eBRLh6dzr2XjmRSTpJ6/XhICV9E+kxzq58n3t/NT/66lbqmVlJiI5k9Kp0LRqZRkB5HTvIgUmIjdfffT5TwRaTPVdU38c7WQyzbcoh3th6ioq7p+HODIsKYmpfEvHOGMHdCFkkxmvahryjhi0i/avVbtpUfZW/FMfZW1LOnop5lW8rZfaSeiDDDnHGZfPOKsQxNifE61AFHA69EpF+F+QxjshIYk5VwfJ+149iwr4Yla/bx1IclvL35EF+9fBS3nJd/xlW+pOf0Lywi/cYYw4TsRP79yrH89SuzOa8gle+9sonPPPQ+e47Uex3egKeELyKeyE4axMP/VMiD86eyp6Keax78G+9vP+x1WANaQCZ8Y8w8Y8zi6upqr0MRkT5kjOGqcwbz53/+FOlxUSx4dAUPv7fzhMZe6T1qtBWRgHC0oZn7fr+aNzeVA+4bwPT8ZP79qrFkxEd7HF1wUaOtiAS0+OgIFi8oZPmuCtaVVbGurIbXNhzg7zuO8Iubp3Du8FSvQwx6SvgiEjB8PsOsglRmFbjkvvlADXc/tYr5v/mQaydn09zqp/pYM3MnZDF/Rq4Gcp2lgKzhi4gAjMlK4M/3fIprJg1h2ZZyNu6roazqGPf/cT3f+tN6mlv9XocYVHSHLyIBLT46gp/eNOX4Y7/f8sPXt7DonR1sPXiUqbnJRIT5KMiIZc64LOKilNZOR/8yIhJUfD7DN64Yw/D0WH742hbWlVXT1OLHbyE6Yh1zx2fxH9dOIHFQhNehBhwlfBEJSp8rHMrnCocC7q5/1Z5K/rS6jN+v3EtJRT1P3jZTd/snUQ1fRIKez2cozE/he9dN5Jfzp7KutJovPraCow3NXocWUJTwRWRA+fT4LH520xSKSyqZ9cBSvv78Wjbtr/E6rICghC8iA85V5wzmxbs/xRUTsnhp7T4+u+gDJX2U8EVkgJo8NIkffXYSb311NnFR4dz2+ErKaxq8DstTSvgiMqANThzEI7cUUnWsmX9Y/CH/9eom/ry6jO3ltadcnH0gUxO2iAx444cksnhBIT98fTOP/303TW0DtuKiwvn8ubl8aXZBSKzApcnTRCSkNLf62Xawlo37a3hn6yFeXruPuKhwHpw/lQtHpXsdXq843eRp/VrSMcbEGmOKjDFX9+f7ioi0iwjzMW5IAjdOy+EXN0/hL/9yAdlJg7jjt0W8v2Ngz8ffpYRvjHnUGFNujFl/0v65xpgtxpjtxphvdOFUXwee606gIiJ9YUxWAr+7fSZ5qTHc9ngRa/ZWeR1Sn+nqHf7jwNzOO4wxYcCDwBXAOOBmY8w4Y8xEY8zLJ20Zxpg5wEagvBfjFxHpsdS4KJ66fSYpsZHc+WQxh442eh1Sn+hSwrfWvgtUnLR7BrDdWrvTWtsEPAtca61dZ629+qStHLgIOBeYD9xhjDnlextjFraVfYoOHTrU3b9LROSsZMRHs/gL06g61sTCJ4v400dlFJdU0DKAZuTsSS+dbGBvp8elwMzTHWytvR/AGHMLcNhae8p/RWvtYmAxuEbbHsQnInJWxg9J5BES0lIAAAYISURBVH8+O4n7fr+aL/9+NQDJMRHMn5nL1y4fHfTz7/d7t0xr7eP9/Z4iIl119TlDmD0qnYM1DWw9WMsLxaU8+PYOJg9NZs64TK/D65Ge9NIpA4Z2epzTtq/HtIi5iHgpPjqCERnxXDlxMIsWTGNERhz/+fJGGppbvQ6tR3qS8FcCI40xw4wxkcBNwJLeCMpa+5K1dmFiYmJvnE5EpNsiwnx8d9549lTU86PXtwR1Tb+r3TKfAT4ARhtjSo0xt1lrW4B7gNeBTcBz1toNfReqiIg3zh+ZxucKc3jkb7u47qG/8/LafdQ2tngd1lkLyJG2xph5wLwRI0bcsW3bNq/DERHBWssr6/bzvZc3caCmgbiocP5w1yzGDk7wOrSPOd1I24BM+O00tYKIBJpWv2Xl7gru/t0qhqXF8oc7Z3GotpG0uCjCfIHRiycgplYQEQl2YT7DucNT+cYVYyguqWT+wx9y7gNvceeTxQFf3w/IhK9eOiIS6G6cmsOM/BSKdldyyegM3tx0kPv/uD6gp1xWSUdEpJtqG1uoa2whMyGaH7+xhZ8v3c4FI9P42U1TSIn1brpllXRERHpZXFQ4mQnRANw3ZxQPXD+R5bsquP2JlQF5p6+ELyLSC4wx3Dwjl/++YSKr9lTx+Pu7vQ7pYwIy4auGLyLB6rrJ2Vw6JoMfvb6ZpZsPAuAPkLt91fBFRHpZeU0D//TYSjbtryE9PoqmFj+/XjCNc4en9sv7q4YvItJPMhKi+ePd53HvJSO4YGQaKbGR3PVUMTsP1XoalxK+iEgfiI4I46uXj+bHn5vM41+cjgGu/eXfeb641LOYlPBFRPpYXmosf/7n8xk7JIGv/WENf/zIm6QfkAlfjbYiMtDkpsbw1G0zmTksha+/sI77/7iO5TuP9GsMAZnwNT2yiAxEkeE+Fv3jNGYNT2XJ6n3802Mr2HLgaL+9f0AmfBGRgSo5NpInbp3B0q9dRFxUBAufLGLxuzuorm/u8/dWwhcR8UB6fBQPfX4qBvivVzdz46L3OVjT0KfvqYQvIuKRGcNSWPavF/P0HTPZV3WMmxd/SEVdU5+9X0AmfDXaikgoOa8gjcdvnUFZ1TG++NgKqur7JukHZMJXo62IhJrp+Sk8OH8qm/Yf5R9+/SEHqnu/vBOQCV9EJBRdNi6Tx784ncr6JsqP9n7CD+/1M4qISLedNyKNd//tYqIjwnr93LrDFxEJMH2R7EEJX0QkZCjhi4iECCV8EZEQEZAJX/3wRUR6X0AmfPXDFxHpfQGZ8EVEpPcp4YuIhIiAXsTcGHMIKDnN04nAJxX504DDvR6Ud8709wbT+/bGObtzjrN9TVePP9Nx+qwG7/sG62c1z1qb/rGjrLVBuQGLz/B8kdcx9uffG0zv2xvn7M45zvY1XT2+C59FfVaD9H0H2mc1mEs6L3kdQD/z6u/ti/ftjXN25xxn+5quHn+m4/RZDd73HVCf1YAu6fSEMabIWlvodRwiZ6LPqvSXYL7DP5PFXgcg0kX6rEq/GLB3+CIicqKBfIcvIiKdKOGLiIQIJXwRkRARMgnfGBNrjHnCGPMbY8znvY5H5HSMMcONMY8YY573OhYZWII64RtjHjXGlBtj1p+0f64xZosxZrsx5httu68HnrfW3gFc0+/BSkg7m8+qtXantfY2byKVgSyoEz7wODC38w5jTBjwIHAFMA642RgzDsgB9rYd1tqPMYrA2X1WRfpEUCd8a+27QMVJu2cA29vukpqAZ4FrgVJc0ocg/7sl+JzlZ1WkTwzExJdNx508uESfDbwI3GCM+RWhN9RdAtMpP6vGmFRjzCJgijHmm96EJgNRuNcB9BdrbR3wRa/jEDkTa+0R4C6v45CBZyDe4ZcBQzs9zmnbJxJo9FmVfjUQE/5KYKQxZpgxJhK4CVjicUwip6LPqvSroE74xphngA+A0caYUmPMbdbaFuAe4HVgE/CctXaDl3GK6LMqgUCTp4mIhIigvsMXEZGuU8IXEQkRSvgiIiFCCV9EJEQo4YuIhAglfBGREKGELyISIpTwRURChBK+iEiI+P8ZhL95aZPqbQAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "VnEoiDm-sz2V"
+      },
+      "source": [
+        "# This is not the right way to do this with edward, but...\n",
+        "import tensorflow_probability as tfp \n",
+        "tfd = tfp.distributions\n",
+        "\n",
+        "p = tf.tile(tf.expand_dims(fid_params,0), [batch_size, 1])\n",
+        "\n",
+        "def log_prob_fn(params):\n",
+        "  k, pk = get_pk(logMmin=params[:,0],\n",
+        "              sigma_logM=params[:,1], \n",
+        "              logM0=params[:,2], \n",
+        "              logM1=params[:,3], \n",
+        "              alpha=params[:,4])\n",
+        "  return tfd.MultivariateNormalDiag(loc=mean,scale_diag=diag_std).log_prob(pk)"
+      ],
+      "execution_count": 13,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "wJ0Xps3Fup5h",
+        "outputId": "8ec08139-6668-4bc0-a0a1-f02c3ff70738"
+      },
+      "source": [
+        "log_prob_fn(p)"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<tf.Tensor: shape=(2,), dtype=float32, numpy=array([455.54333, 446.72443], dtype=float32)>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 14
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "778GG5HvvjSt"
+      },
+      "source": [
+        "num_burnin_steps = int(1e1) #oops....\n",
+        "num_chains = batch_size\n",
+        "\n",
+        "#tfp.mcmc.SimpleStepSizeAdaptation(\n",
+        "adaptive_hmc = tfp.mcmc.HamiltonianMonteCarlo(\n",
+        "        target_log_prob_fn=log_prob_fn,\n",
+        "        num_leapfrog_steps=3,\n",
+        "        step_size=2e-6)#, #can play a lot with this number...\n",
+        "#    num_adaptation_steps=int(num_burnin_steps * 0.8))"
+      ],
+      "execution_count": 99,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FLDTtUbgwf8q"
+      },
+      "source": [
+        "#start spread out around some point\n",
+        "var = (np.random.random([num_chains, 5])-0.5)*np.array([0.1,0.02,0.01,0.1,0.01])*10"
+      ],
+      "execution_count": 100,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1KgHdayrvjmb"
+      },
+      "source": [
+        "num_results = 1000\n",
+        "\n",
+        "# Initial state of the chain\n",
+        "init_state = tf.Variable(np.ones([num_chains, 5], dtype=dtype)*fid_params+var,dtype=float32)"
+      ],
+      "execution_count": 101,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "I5CeUgkGlplx",
+        "outputId": "8426fe72-535b-48e5-822d-8d71d1562dce"
+      },
+      "source": [
+        "init_state"
+      ],
+      "execution_count": 102,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<tf.Variable 'Variable:0' shape=(2, 5) dtype=float32, numpy=\n",
+              "array([[11.910663  ,  0.26596314, 11.360015  , 13.587226  ,  1.0418508 ],\n",
+              "       [11.569733  ,  0.31233606, 11.355863  , 13.039662  ,  1.096135  ]],\n",
+              "      dtype=float32)>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 102
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "aiUhkSVCwgr6"
+      },
+      "source": [
+        "@tf.function\n",
+        "def run_chain():\n",
+        "  # Run the chain (with burn-in).\n",
+        "    samples, trace = tfp.mcmc.sample_chain(\n",
+        "      num_results=num_results,\n",
+        "      #num_burnin_steps=num_burnin_steps,\n",
+        "      current_state=init_state,\n",
+        "      kernel=adaptive_hmc)\n",
+        "#      trace_fn=lambda _, pkr: pkr.inner_results.is_accepted)\n",
+        "\n",
+        "    return samples, trace"
+      ],
+      "execution_count": 103,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "a8yOcettwl3z",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "01b5389a-2734-4707-fd80-a42a659c78b6"
+      },
+      "source": [
+        "import time\n",
+        "current_time = time.time()\n",
+        "q,is_accepted = run_chain()\n",
+        "run_time = time.time()-current_time\n",
+        "print(run_time)"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/tensorflow_probability/python/mcmc/sample.py:342: UserWarning: Tracing all kernel results by default is deprecated. Set the `trace_fn` argument to None (the future default value) or an explicit callback that traces the values you are interested in.\n",
+            "  warnings.warn('Tracing all kernel results by default is deprecated. Set '\n"
+          ],
+          "name": "stderr"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "BtahWJGSlZir",
+        "outputId": "c060246c-c3e1-4661-966b-2884ddeacf4c"
+      },
+      "source": [
+        "is_accepted.is_accepted"
+      ],
+      "execution_count": 96,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<tf.Tensor: shape=(10, 2), dtype=bool, numpy=\n",
+              "array([[ True,  True],\n",
+              "       [ True, False],\n",
+              "       [ True, False],\n",
+              "       [False,  True],\n",
+              "       [False, False],\n",
+              "       [False, False],\n",
+              "       [ True, False],\n",
+              "       [False, False],\n",
+              "       [ True, False],\n",
+              "       [False, False]])>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 96
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "eep87N8hlZVR"
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "nuNtGu8PlJiV",
+        "outputId": "8e58139f-9bb3-4a5b-954e-4be5839bd7e1"
+      },
+      "source": [
+        "init_state"
+      ],
+      "execution_count": 61,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<tf.Variable 'Variable:0' shape=(2, 5) dtype=float32, numpy=\n",
+              "array([[12.020327  ,  0.2599496 , 11.380009  , 13.309808  ,  1.0599847 ],\n",
+              "       [12.020145  ,  0.26000974, 11.379963  , 13.309797  ,  1.0600109 ]],\n",
+              "      dtype=float32)>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 61
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "LgJVwq7Pwnts",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "95e621c6-7aed-4e3f-f55c-341e0f587bb5"
+      },
+      "source": [
+        "q.shape"
+      ],
+      "execution_count": 49,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "TensorShape([10, 2, 5])"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 49
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "IRRtZH81jMhy"
+      },
+      "source": [
+        "import corner"
+      ],
+      "execution_count": 24,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "M8L2mBmVjwvG",
+        "outputId": "db2a3d85-8504-44e0-fde3-821d5768fbd7"
+      },
+      "source": [
+        "is_accepted"
+      ],
+      "execution_count": 50,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<tf.Tensor: shape=(10, 2), dtype=bool, numpy=\n",
+              "array([[False, False],\n",
+              "       [False, False],\n",
+              "       [False, False],\n",
+              "       [False, False],\n",
+              "       [False, False],\n",
+              "       [False, False],\n",
+              "       [False, False],\n",
+              "       [False, False],\n",
+              "       [False,  True],\n",
+              "       [False, False]])>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 50
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "dxLPFGD3jbaI",
+        "outputId": "5777ae40-58b4-4e48-fbc7-c938e4a4338d"
+      },
+      "source": [
+        "corner.corner(np.array(q[:,:,:]).reshape(-1,5)[:]);"
+      ],
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n",
+            "WARNING:root:Too few points to create valid contours\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAywAAAM5CAYAAADllbW1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzde7RdZX3u8e8DCYgiIM0GRY3bFoEAEiCRcinBFkWoGgtiESunERxgtdrWKh70tPV4LJwqihdQD1aKVaCihQq2RbRFuQjqTiWAFi+oICgQLKBBQ4D8zh9rhgbIzey913yT/f2MsUfWZa45nxXm2Obxne87U1VIkiRJUos26TuAJEmSJK2OhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1a1rfASbbjBkzanR0tO8Y2kAtXLjwrqoa6TuHJEnSVLXRF5bR0VHGxsb6jqENVJKb+84gSZI0lXlJmCRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkbfWG5/vrrSbLKn9HR0b7jqQGjo6OrPUckSZLUr2l9B5hsy5Yto6pW+Z7/IBXAzTff7DkiSZLUqI1+hEWSJEnShsvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSs6Z8YXnzm9/MLrvswh577MHhhx/OPffcs8rt7rnnHo488kh22WUXZs2axdVXXz3uYx966KFss802vOhFLxr3viRJkqSN0ZQqLF/60pdYsGDBI157/vOfzw033MB1113HTjvtxCmnnLLKz/7Jn/wJhx56KDfeeCOLFi1i1qxZ487z5je/mU984hPj3o8kSZK0sZpShWVVDjnkEKZNmwbAvvvuy6233vqYbe69914uv/xyjjvuOAA222wzttlmGwBuuukmDj30UObMmcOBBx7IjTfeuM7HPvjgg3niE584Ad9CkiRJ2jhN+cKysrPOOovDDjvsMa//4Ac/YGRkhFe96lXstddevPrVr+a+++4D4Pjjj+eDH/wgCxcu5NRTT+W1r33tsGNLkiRJG61UVd8ZJlWSxcAWDMrZJsA0YFn39q3Az7rHTwaeANy0it08HpgF3AjcBzwd2Bz4PrAnsHTlQwLfBLYBnrqKfS0DvrvS8ycC2wPf+9W+2SrNAO6agP1MpA090zOqamQyw0iSJGn1NvrCsrIkzwUWVNWCR72+ADgBOLiqfrGKzz0ZuKaqRrvnBwIXAzOBb1fVU8aZ6U1VNe6Z90nGqmruePczkcwkSZKk8Zjyl4QlORQ4EZi/qrICUFW3Az9KsnP30sHA0qr6GfCDJC/r9pUks4eRW5IkSZoKpnxhAU5ncFnWF5Jcm+QjAEl2SPIvK233euCcJNcxuAzsJ93rfwAcl2QRg0vBXrKuB05yBfBp4OAktyZ5wfi/jiRJkrTxmFKXhE2kJMdX1Zl951iZmdZNi5kkSZK0ahYWSZIkSc3ykjBJkiRJzZrWd4DJlmSNQ0hz5swZVhRtgBYuXHjX6pY1njFjRo2Ojg45kTYWazq3JEnSf9voC8vajI2N9R1BDUty8+reGx0d9fzRelvTuSVJkv6bl4RJkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktSsDaawJEnfGSRJkiQNV9OFJclTk4wCVFVZWiRJkqSppdnCkuR3gX8FzkxyAQxKy6+6nzlz5lBVq/2RJEmS1K4mC0uSOcD/BU4AXgA8mGSrflNJkiRJGrYmCwsQ4N+q6mrgqcCBwLuT/EOSzWDNc1qSHJ9kLMnY4sWLh5NYkiRJ0oRrtbAsBXZL8j7gcuD9wP8EHg98GtZ8eVhVnVlVc6tq7sjIyDDySpIkSZoE0/oOsEKSecBvAt8AvsrgcrAdgO2BD1TVL4D5Sf41ya9V1U/7SytJkiRpGJoYYUlyCPB3wAzgJcCFwPZVdRWwBJjdbff7wK8BD/QUVXrY9ddfT5JV/oyOjvYdTw0YHR1d7TkiSZLWTSsjLLOBM6rqvUm2Bl4GfDTJy4BLGawU9g3g2cAxVfWzHrNKACxbtmy1K835D1IB3HzzzZ4jkiSNUyuF5T5gb4Cquhf4225S/XuB3wO+A0wHFlfVzb2llCRJkjRUvV0S1t0Ucmb39GxgnyQnr7TJBcCPgDlVtaiqxiwrkiRJ0tTSS2FJciSDQvKZJKcwGF15AbB/95xuUv2mwF59ZJQkSZLUv6FfEtbNUflz4I+AOxhMsj8G+DLwcuDzSbYD7mZw/5W/GXZGSZIkSW3oYw7LpsCDwD1VdVuSTwGLgecB3wP2Aw4HtgEOr6rv9pBRkiRJUgOGXliq6r+S/BvwziR/WlV3JrkMeBowv6q+Bpwz7FySJEmS2jOUOSxJXpTk5CRnJJkBnAt8GzgxyfZVdReDOS3PTfLkYWSSJEmS1L5JLyxJ5gAfAa4BtgDeD+wKXA38HDgjyc7Avt1Hlk52JkmSJEkbhmGMsOwEXFpVF1XVscCVwCHA4xgsZ3wd8D7gNcAbquqeIWSSJEmStAEYRmH5KrBDkv0BqurDwA3AK4C7q+odDO5sf1hV/ccQ8kiSJEnaQExKYUmyZ5JZSXatqu8DC4EDk+wCUFUfYrBS2End8yVV5aVgkiRJkh5hwgtLksOAi4HXAecneSnwMeDXgZckOajb9GsM5rBIkiRJ0ipN2LLGSQI8AXg98LqquijJfsAngbcCpwALgLcnuQPYH3jhRB1fkiRJ0sZnwgpLVRWwJMkYsFWS6VV1dZKjgfOBN1bV25M8DdgLOLGqbpmo40uSJEna+EzGHJbbgYMZLGFMdyPIY4C3JvmNqrq1qi62rEiSJElamwkrLN0lYSsm1D8e+HCSrbuRlisYLF/80EQdT5IkSdLGb1yXhHU3fNwWGAOW0xWSqjoqyXkM7q9yTZJpwEEMVgaTJEmSpHWy3oUlyRHAycBt3c9YkrOr6mcAVXV0kmOBHYDZwPyqunUCMkuSJEmaItarsCSZDhwFHFdVV3VLF+8LvCXJu6rqXoCqOqvbfvOqun+iQkuSJEmaGsYzh2Ur4Fnd4wuBzwHTgaMBkuyTZO/u/WXjOI4kSZKkKWq9CktVPQC8FzgiyYFVtRy4ErgWmJdkC+AA4Mfd9jVBeSVJkiRNIeMZYbkCuBQ4Jsm8qnqoqs5lMGdlh6o6rapun5CUkiRJkqak9Z50X1VLk5wDFHBSkl2A+4ERYMkE5ZMkSZI0hY1rWeOqujvJR4FvAScAS4FXVtUdExFOkiRJ0tQ2rsICUFXLgMuSXD54WsvHH0uSJEmSJqCwrFBV3sVekiRJ0oQaz6T7SZdkxySb9Z1DkiRJUj+aLSxJRoHvACck2brfNJIkSZL60GxhYXCzye8DLwJemWSrnvNIkiRJGrIJm8My0arqx90KZDcBrwXuTfJd4L+q6rtr+myS44HjAWbOnDnpWSVJkiRNjmZHWJJMA57J4J4uRwJvBK4C1tpAqurMqppbVXNHRkYmN6gkSZKkSdPMCEuSecA+wCLgpqr6fpLzgKcAWzG4IeV1wGiSJ1bVz/tLK0mSJGkYmhhhSXII8HcMSskLgY8m2Rf4AXAqcDXwPxiMtLwEmN5TVEmSJElD1MoIy2zgjKp6b7ci2MuAjwKHAycB91bVZQBJjqqqX/YXVZIkSdKwtFJY7gP2Bqiqe4G/TbIJ8EHg1VV1W/e8gKX9xZQkSZI0TL1dEpbkqUlWTKA/G9gnyckrbXIB8EPgGQBVtbw6Qw0qSZIkqTe9FJYkRzIoJJ9JcgqD0ZUXAPt3z6mquxjMVdmzj4ySJEmS+jf0S8K6OSp/DvwRcAeDSfTHAF8GXg58Psl2wN3AgcDfDDujJEmSpDb0MYdlU+BB4J5ubsqngMXA84DvAfsxmGy/DXD42m4SKUmSJGnjNfTCUlX/leTfgHcm+dOqujPJZcDTgPlV9TXgnGHnkiRJktSeocxhSfKiJCcnOSPJDOBc4NvAiUm27+arXAA8N8mTh5FJkiRJUvsmvbAkmQN8BLgG2AJ4P7Arg5tB/hw4I8nOwL7dR1y2WJIkSRIwnBGWnYBLq+qiqjoWuBI4BHgcg+WMrwPeB7wGeENV3TOETJIkSZI2AMMoLF8FdkiyP0BVfRi4AXgFcHdVvYPBne0Pq6r/GEIeSZIkSRuISSksSfZMMivJrlX1fWAhcGCSXQCq6kMMVgo7qXu+pKq8FEySJEnSI0x4YUlyGHAx8Drg/CQvBT4G/DrwkiQHdZt+jcEcFkmSJElapQlb1jhJgCcArwdeV1UXJdkP+CTwVuAUYAHw9iR3APsDL5yo40uSJEna+ExYYamqApYkGQO2SjK9qq5OcjRwPvDGqnp7kqcBewEnVtUtE3V8SZIkSRufyZjDcjtwMIMljOluBHkM8NYkv1FVt1bVxZYVSZIkSWszYYWluyRsxYT6xwMfTrJ1N9JyBYPlix+aqONJkiRJ2viN65Kw7oaP2wJjwHK6QlJVRyU5j8H9Va5JMg04iMHKYJIkSZK0Tta7sCQ5AjgZuK37GUtydlX9DKCqjk5yLLADMBuYX1W3TkBmSZIkSVPEehWWJNOBo4DjquqqbunifYG3JHlXVd0LUFVnddtvXlX3T1RoSZIkSVPDeOawbAU8q3t8IfA5YDpwNECSfZLs3b2/bBzHkSRJkjRFrVdhqaoHgPcCRyQ5sKqWA1cC1wLzkmwBHAD8uNu+JiivJEmSpClkPCMsVwCXAsckmVdVD1XVuQzmrOxQVadV1e0TklKSJEnSlLTek+6rammSc4ACTkqyC3A/MAIsmaB8kiRJkqawcS1rXFV3J/ko8C3gBGAp8MqqumMiwkmSJEma2sZVWACqahlwWZLLB09r+fhjSZIkSdIEFJYVqmrC72KfJE7YlyRJkqau8Uy6H4atkzycMUn6DCNJkiRpuJotLEnmA18ATk/yQXB5ZEmSJGmqabKwJNkJ+GvgfwLvAvZIcn6Sx3XvO9IiSZIkTQFNFhbg58B3gEVV9cOqOgjYFPgErH2kJcnxScaSjC1evHjy00qSJEmaFK0Wll8A9wJzVrxQVS8Ftk9y6to+XFVnVtXcqpo7MjIyiTElSZIkTaZmCkuSeUnelOT5DHJ9CjglyT4rbfYaGsosSZIkaXI18Y//JIcAfweMAC8GPg18G3gn8KEk85M8BdgfmJtki97CSpIkSRqaCbsPyzjNBs6oqvcm2Ro4CrgImA+cBLwUOBZ4GnBsVf2yt6SSJEmShqaVwnIfsDdAVd0LnNktBPYh4GjgKmALYFpV3dFXSEmSJEnD1dslYUmemmRm9/RsYJ8kJ6+0yT8CtwC7VtUvquqnlhVJkiRpaumlsCQ5ErgA+EySUxiMrrwA2L97TlX9lMEI0F59ZJQkSZLUv6FfEtbNUflz4I+AO4CXAMcAXwZeDnw+yXbA3cCBwN8MO6MkSZKkNvQxh2VT4EHgnqq6LcmngMXA84DvAfsBhwPbAIdX1Xd7yChJkiSpAUMvLFX1X0n+DXhnkj+tqjuTXMZgBbD5VfU14Jxh55IkSZLUnqHMYUnyoiQnJzkjyQzgXAb3WTkxyfZVdReDOS3PTfLkYWSSJEmS1L5JLyxJ5gAfAa5hsDTx+4FdgauBnwNnJNkZ2Lf7yNLJziRJkiRpwzCMEZadgEur6qKqOha4EjgEeByD5YyvA94HvAZ4Q1XdM4RMkiRJkjYAwygsXwV2SLI/QFV9GLgBeAVwd1W9A3gZcFhV/ccQ8kiSJEnaQExKYUmyZ5JZSXatqu8DC4EDk+wCUFUfYrBS2End8yVV5aVgkiRJkh5hwgtLksOAi4HXAecneSnwMeDXgZckOajb9GsM5rBIkiRJ0ipN2LLGSQI8AXg98LqquijJfsAngbcCpwALgLcnuQPYH3jhRB1fkiRJ0sZnwgpLVRWwJMkYsFWS6VV1dZKjgfOBN1bV25M8DdgLOLGqbpmo40uSJEna+EzGHJbbgYMZLGFMdyPIY4C3JvmNqrq1qi62rEiSJElamwkrLN0lYSsm1D8e+HCSrbuRlisYLF/80EQdT5IkSdLGb1yXhHU3fNwWGAOW0xWSqjoqyXkM7q9yTZJpwEEMVgaTJEmSpHWy3oUlyRHAycBt3c9YkrOr6mcAVXV0kmOBHYDZwPyqunUCMkuSJEmaItarsCSZDhwFHFdVV3VLF+8LvCXJu6rqXoCqOqvbfvOqun+iQkuSJEmaGsYzh2Ur4Fnd4wuBzwHTgaMBkuyTZO/u/WXjOI4kSZKkKWq9CktVPQC8FzgiyYFVtRy4ErgWmJdkC+AA4Mfd9jVBeSVJkiRNIeMZYbkCuBQ4Jsm8qnqoqs5lMGdlh6o6rapun5CUkiRJkqak9Z50X1VLk5wDFHBSkl2A+4ERYMkE5ZMkSZI0hY1rWeOqujvJR4FvAScAS4FXVtUdExFOkiRJ0tQ2rsICUFXLgMuSXD54WsvHH0uSJEmSJqCwrFBV3sVekiRJ0oQaz6R7SZIkSZpUG0xhSZK+M0iSJEkarqYLS5LnJDkYBpNjLC2SJEnS1DJhc1gmUldMngR8DviPJE+sqn/qSsuma5svk+R44HiAmTNnTn5gSZIkSZOiyRGWGvgv4B+BK4HfTvKy7r21Tu6vqjOram5VzR0ZGZnktJIkSZImS7MjLFVVwB3AE4Drgd9KMgr8oqrOWJeRFkmSJEkbtmZHWLqHXwZ+VFV/CywD3gFs221jWZEkSZI2cs0UliTzk3wkyZlJ9upevhnYLckRwEuBjwEzk8zvLagkSZKkoWmisHQF5VTgn4HvAB/v5qz8EtgcOA3446r6YwZzWsb6yipJkiRpeFqZw/J0YFFVXQxcnOT7wKuBe4DzgU9W1Ze7bc+pqgd7yilJkiRpiJoYYQG+ASxNMqebcH8BcDaDUZfbqurLSTbp3rOsSJIkSVNEb4Wluynkvkn2qKofAT8BjgSelmSTqjof+BTwhwBVtXylyfiSJEmSpoBeLglLchjwAQargD0lyRhwEoNJ9a8FLgKuBu4DZvSRUZIkSVL/hl5YkkxncBf6v6yq85JsB3yRwf1WjmOwdPHrk7wN+A3g5cPOKEmSJKkNQy8sVfVAkoXAQ93zO5PszWDlr7dV1duSjACzgW93l4tJkiRJmoKGNoclyZNWevpd4G1JZgB0E+lfCOyd5FlVtbiqvmhZkSRJkqa2oYywJHkR8NokdwBXAJ8Engl8PclzququqrotyVLg8cPIJEmSJKl9k15YkuwEfAR4BTAKPAv4OIP5KgV8Icn7ge2APRjce0WSJEmShjLC8iDw+aq6HLg8ydOBVwEfBRYwuDzsGQzmrPx+Vd08hEySJEmSNgDDKCx3A/sk+ZOqen9V/SjJ2cBrgCOr6jyA7t4ry4eQR5IkSdIGYlIm3SfZP8kfJvntqrob+B/AYUlW3ATyFuBm4KAVn7GsSJIkSXq0CS8sSZ4PXMxgvsp7kvwl8CTgVOAPkryx23QpMCOJk+wlSZIkrdKEXhKWJMBc4I1V9fEk/wgcDjwPuBT4c+Dvk+wBPBeYX1W/mMgMkiRJkjYeE1pYqqqS3Ae8MsmFVXVDkl8ArwR+q6remeQgYItu8zsn8viSJEmSNi6TMYflk8AiBpd/Pb6qvg/8E/CKJAdU1c+q6g7LiiRJkqS1GVdh6S4Be7R7gK8zuN/KgiRbVdV1DC4J2248x5MkSZI0tYz3krBNGdxnBYAk06rqwSSfAZYD+wL/kuSfgT8APjDO40mSJEmaQta7sCQ5DDguyULg1qr6RFdWplfVA11pWVFUNgfmdZeHSZIkSdI6Wa/CkmQfBqMlb2cwknJSkllV9daurEyrqgeBXwAfTZKqqglLLU2QVV/VKEmSpFas7wjLZsCXquocgCRfAr7S9ZK3dSMtBwF7V9VplhVJkiRJ62N9J93/Etg+ybYAVfUTYD8Gd7M/qtvmLuDT448oSZIkaapar8JSVQuBW4FLVnrtduAMupXAquqbVXXrRISUJEmSNDX9yoUlyWYAVfVa4M4kVyZ5cvf2DGBukk1Ws+RxL4499li22247dt999wnZ36abbsqee+7Jnnvuyfz589f5czfeeCP77bcfm2++Oaeeeupqtzv99NPZcccdScJdd9318Ouf/exn2WOPPdhzzz2ZO3cuV1555cPvnXjiiey2227MmjWLN7zhDaztKrzVHUOSJElqya9UWJJsUlXLuscnAe8BvgF8KMk/AAuAd1XV8pbmrSxYsIBLLrlk7Ruuoy222IJrr72Wa6+9losuumiV24yOjj7mtW233ZYPfOADvOlNb1rj/g844AC++MUv8oxnPOMRrx988MEsWrSIa6+9lrPOOotXv/rVAHzlK1/hqquu4rrrruOGG27g61//Ol/+8pfX6xiSJElSS9a5sHRlZXn3+F3Ai6rqsqp6PfA24N3AYVX1zcmJuv7mzZvHtttu+4jXbrrpJg499FDmzJnDgQceyI033jjpObbbbjue85znMH369DVut9dee62y8Gy55ZYPr2p13333Pfw4CUuXLmXZsmXcf//9PPDAA2y//fYAXHrppey3337svffevOxlL2PJkiVrPIYeY3bfASRJkqayrMtAyKPKyqnAbsCLu6WLm5ZkMXAzg5XNngWsKFQ7da/fDzwBeCrwnXXc7RxgGfAAcDtwzyq2eTZw/Wo+vwPwEHDHWo7zbOA/WenmnMA2XdbpwHeB+7rXn8Zg/tByYDFwG4NV4H6j22458GQgwE/WcoyJNIPBAgwtWddMs4FpVbXKyxtXOrf61MrfrzkeaV1yPKOqRoYRRpKkDdk6FZaHN07eA8wC5ndLF29aVQ9NWroJlGQU+FxV7Z5kSwb/qP/2SptsXlWzkhwBvGMVu7itql7Q7eupwGeB3wf+HTi4qm5KcgZwQLf9rsC3usefrqq/XinL24ElVbX6iSyD7X4IzK2qx/zDJ8k84C+r6nlJdgTeDzwFmAd8ATgR2Bo4m8ECCTAobVdX1XHrcoyJkGSsquZOxr7XV4uZ1lcr38UcbeaQJGljsM73YUkyE9iZDbCsrMImwD1Vteej36iqC4AL1vThqrotCVX1/e4eNHsBN1XV61Zsk+SHq9r/RKmqy5P8epIZwOHANcBLqmpJkn9lsMz0fwJfqKqjJyuHJEmSNJnWeQ5LVd1CdxnYBl5WqKqfAT9I8jKADKzTXIUkT0qyefd4BoMRlW+t+VMTI8mOK1ZfS7I3sDnwU+AW4KDu9end4/9kUGIO6EZgSPKEJDsNI6skSZI0EX6lVcJWrPy1oZWVJOcBVwM7J7k1yXHAHwDHJVnEYF7LS9Zxd7OAMWB74DLg/1bVOhWWJE9OcivwRuB/dVm26t77lyQ7dI/f0G33NOC6JH/b7eKlwA1JrmVwz5ujuv8mnwFuYjC3ZRGwqKourqrFDFZuOy/Jdd3fwS5rOcZEO3OS9jseLWZaX618F3M8Uis5JEna4P1Kc1gkSZIkaZjW6073kiRJkjQM6zzpfkM1Y8aM8n4jWp2FCxeudZs1LGu8xuHJOXPmrGcqTQULFy68a3XLGvt7S+OxpnNLkjZEG31hGR0dZWxsrO8YatSKm2+uwXrfn8bzTmuSZLX38PH3lsZjTeeWJG2IvCRMWrNFfQeQJEmayiwskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFk1pVbXGnzWZM2fOen9WkiRJ68bCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZGkxlx//fUkeczP6Oho39HUmNHR0cecJ5K0sZnWdwBJ0iMtW7ZslUtj+49RPdrNN9/8mHPF80TSxsYRFkmSJEnNsrBIkiRJapaFRZIkSVKzNqjCkmSDyitJkiRpfJqedEFNxCUAACAASURBVJ/khcA+wGbAqVX1054jSZIkSRqiZkcskvwmcDrwbeBJwEVJ9k8yfR0+e3ySsSRjixcvnuyomkI8tyRJkoar2cIC7A5cWlXnVtVrgH8ETgTmwJovD6uqM6tqblXNHRkZGU5aTQmeW5IkScPVcmH5OrBFkl0Aquq9wJXAaUm2qarlvaaTJEmSNOlaLiy3Aw8Cz08yA6CqTgVuAE7oM5gkSZKk4WiqsCTZdMXjqroT+CDwAuDoJM/u3roJeOwtoCVJkiRtdJpYJSzJTlX1nap6KMmm3Z+pqm8k+QsGIyoHJCkGq4b9Xr+JJUmSJA1D7yMsSV4EXJvkXICVSksl2aSqvgH8L+AvgIuB51XV9T1GliRJkjQkvRaWJE8A/hj4U2BZkk/Cw6Vl2koT6x+squ92K4b9oK+8kiRJkoar18JSVfcBxwLnAm8CHrdSaXkQIMls4JVJHpckvYWVJEmSNHS9XxJWVT+uqiVVdReDuSpbrCgtSfYAdgTOr6qlVeVke0mSJGkK6b2wrKyqfsqgtDyQ5NsMbhb5lW7FMEmSJElTTFOFBaAbabkO2Bo4oqp+0nMkSZIkST1prrAkeRLwu8AhrgYmSZIkTW1N3IdlZVV1d5IXV9XSvrNIkiRJ6ldzIywAlhVJkiRJ0GhhkSRJkiSwsEiSJElqmIVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLUrOYLS5LN+84gSZIkqR9NF5YkvwO8OslmfWeRJEmSNHzNFpYkhwLvA66rqmV955EkSZI0fE0WliR7AOcB76iqK5L8WpIZSZ65jp8/PslYkrHFixdPblhNKZ5bkiRJw9VkYQEeB5wPPDnJXOAc4D3A55MsWNuHq+rMqppbVXNHRkYmN6mmFM8tSZKk4WqysFTV14C/B3YEvghcBBwHHAu8M8luPcaTJEmSNCTT+g7waEk2qarlVXVVkuXAFVX1j0lSVVcmuQS4v++ckiRJkiZfE4Ulyc7AtsAYsHzF61V19YoVwqqqkhwF7AX8spegkiRJkoaq98KS5AjgZOC27mcsydlV9bNuVGVZkmnAK4A3AUdX1W09RpYkSZI0JL3OYUkyHTgKOK6qDgY+CzwdeEuSrauqAKrqQeDnwBFV9c3eAkuSJEkaqhYm3W8FPKt7fCHwOWA6cDRAkn2SzKqqC6vqez1llCRJktSDXgtLVT0AvBc4IsmBVbUcuBK4FpiXZAvgAOCeHmNKkiRJ6kkLIyxXAJcCxySZV1UPVdW5wA7ADlV1WlX9pN+IkiRJkvrQ+6T7qlqa5ByggJOS7MJg2eIRYEmv4SRJkiT1qvfCAlBVdyf5KPAt4ARgKfDKqrqj32SSJEmS+tREYQGoqmXAZUkuHzyt5Wv7jCRJkqSNWzOFZYWqeqjvDJIkSZLa0MKke0mSJElaJQuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElq1rS+A6xJkj2B+wGq6j97jiNJkiRpyJodYUlyGHAx8Frg00le1XMkSZIkSUPW3AhLkgBPAF4PvK6qLkqyL/DJJJtX1UfWYR/HA8cDzJw5c1Lzamrx3JIkSRqu5kZYamAJMAZslWR6VV0DvBx4S5IF67CPM6tqblXNHRkZmeTEmko8tyRJkoarucKyktuBg4EtAKpqDDgG+OMkz+wzmCRJkqThaK6wdJeEUVUfAh4PfDjJ1t1Iy5XAdUD1mVGSJEnScDQxhyXJzsC2DC4DWw48BFBVRyU5D3gfcE2SacBBwIN9ZZUkSZI0PL0XliRHACcDt3U/Y0nOrqqfAVTV0UmOBXYAZgPzq+rW3gJLkiRJGppeC0uS6cBRwHFVdVWSlwL7Mphc/66quhegqs7qtt+8qu7vL7EkSZKkYWphDstWwLO6xxcCnwOmA0cDJNknyd7d+8uGH0+SJElSX3otLFX1APBe4IgkB1bVcuBK4FpgXpItgAOAH3fbO9lekiRJmkJaGGG5ArgUOCbJvKp6qKrOZTBnZYeqOq2qbu83oiRJkqQ+9D7pvqqWJjmHwVLFJyXZBbgfGAGW9BpOkiRJUq96LywAVXV3ko8C3wJOAJYCr6yqO/pNJkmSJKlPTRQWgKpaBlyW5PLB01redyZJkiRJ/WqmsKxQVQ/1nUGSJElSG1qYdC9JkiRJq2RhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZzReWJOk7gyRJkqR+NF9YgC37DiBJkiSpH00XliSHAn+f5AmOtEiSJElTT7OFJclhwF8AH6qq+6qqfoXPHp9kLMnY4sWLJy+kphzPLUmSpOFqrrBkYBT4Z+ADVfWFJDsk2b/72Xxt+6iqM6tqblXNHRkZmezImkI8tyRJkoarucJSAz8E3gO8NclzgHOAPwTOAv4sydY9RpQkSZI0JM0VliSbAFTVm4FLgK8CF1bVCcDvA0cCv9lfQkmSJEnDMq3vADC4DGzFHJWqWp5kk6paXlVvSfK5qrqie++6JJcDW/UaWJIkSdJQtDLCsumjX1hppOWKlV47BjgE+I/hRZMkSZLUl95HWLrVwI5LshC4tao+sWKUZaVtNgd+G3grcGRVfb+nuJIkSZKGqNcRliT7AB8ALgR+CLw5ycnw35eGdY/vBxYCz6uqb/YUV5IkSdKQ9T3Cshnwpao6ByDJl4CvdFNa3taVlucCz66qD/aYU5IkSVIP+p7D8ktg+yTbAlTVT4D9gMOSHNVtsxj4p57ySZIkSepRr4WlqhYCtzJYvnjFa7cDZwDbdc+/WVU/6iehJEmSpD71VliSbAZQVa8F7kxyZZInd2/PAOYm2SRJ+sooSZIkqV+9zGHp7rOyrHt8EoO72h8BfCjJMmA2g9XAlveRT5IkSVIbhl5YVtwUsnv8LuCAqjoFuCzJLODxwE+r6ofDziZJkiSpLUMtLI8qK6cCuwEHrXi/qv5zmHkkSZIktW2oc1hWKivvAXYFXlxVDyZ5zJ3uJUmSJGnok+6TzAR2BuavKCtV9dCwc0iSJElq39ALS1XdwkojK5YVSZIkSavTy7LGVVXdn5YVSZIkSavV953uJUmSJGm1LCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWdP6DjDZFi5cSJLVvt+tsCxJE25Nv3skSdK6cYRFkiRJUrMsLJIkSZKa1XxhiddUSJIkSVNW04UlyTzgLUnmJ3n6ZBzj05/+NLvtthubbLIJY2Njq9xm6dKl7LPPPsyePZvddtuNv/qrv3r4veOOO47Zs2ezxx57cOSRR7JkyRIALr/8cvbee2+mTZvGZz7zmXXKcuyxx7Lddtux++67j/+LSZIkSRuBZgtLkt8BLgAeBE4A/izJy9fxs8cnGUuy6gaykt13350LLriAefPmrXabzTffnH//939n0aJFXHvttVxyySVcc801AJx22mksWrSI6667jpkzZ3L66acDMHPmTM4++2xe8YpXrEtkABYsWMAll1yyzttr+FY+txYvXtx3HEmSpI1es4UFeCbw9qo6FXgt8A3gd9altFTVmVU1t6rmrm3bWbNmsfPOO69xmyRsueWWADzwwAM88MADD6/+s9VWW604Jr/85S8ffn10dJQ99tiDTTZ57F/xu9/9bp7znOewxx57PGK0Zt68eWy77bZri6werXxujYyM9B1HG7bZfQeQJGlDkFaX9U2yAHgDcHBV3Z1kBnAYg/+Rf1dV3bmO+ykGozSLgCcCvwb8cBWb7gz8CPjFGna3K7A5cCdwP3BX9/oosDXwS+B7wPKVPjMK3Avc3T3fCngScHP3fEfgdmBJ93wz4FnAN9f65R5rxkqZWrGhZ3pGVa2ymSRZzH//d+xLK3+/5nikteWYDUyrqlXO0XvUudXXd/K4G+6xV/t7S5I2RM0WFoAk7+4evrOq7k3yTOBjwN9U1ed/hf18lUHR2BLYFrile+stK/aT5EvAm6pqjZeRJdkGuBAYqardV3p9U+CDwNer6u9Wev1s4HNV9Znu+anAkcA93SZbAqdU1ce690e77X/liSxJxtZlVGmYzDS5Wvku5pi8HH19J487NY4tSRuCli8JA/h09+dfJNm2qn4AfJ3BqMQ6q6rfrKo9gVcDF1XVnt3POpeelfZ1D3AZgxGVlV9/CPgH4KVr2UUYFJQVGXZcUVYkSZIkPVLrheXrwKeAAr6c5P8ArwIuHWaIJCPdyApJtgCeDyzNwI7d6wHmAzeuZXefB45NsmX3uacm2W7y0kuSJEkbrml9B0gyF7i7qm569Hs1uF5tDFix4lcBB1bVdyfw+IczuJRrBPjnJNdW1QuS7AD8bVX9LvAU4OPdZV+bAOczmHeS7vWtuseLgD/q9vscBpeOPQl4cZL/XVW7VdWlSWYBV3cT9JcArwTuTHIe8FxgRpJbgb/6FUdfzhzXX8bkMNPkauW7mOORJjJHX9/J406NY0tS83qdw5Lk+QxGHC5kMJ/ke72FkSRJktSc3i4J6y6t2htYAPwA+MsVl1c9aruDk5wy5HiSJEmSGtD3CMszgR9WVSX5MPB44K+r6jsrbbMV8KSq6nv5WEmSJElD1tSyxkn+H/A4BjeK/D3gF1V14Tj3ucYvOGfOnPHsXhu5hQsX3rW6+xnMmDGjRkdHh5xIG5KFCxeu8f013IfF31tab2v6vQX+7tL4rO38kiZDb4UlyabdUsAkeVJV3d09PgV4IYNlg/8M+EFVfWMcx1njF2ypsKk9SRau7v4Ic+fOrbGxNd62R1Nct7DG6jxYVdNX8zl/b2m9ren3Fvi7S+OztvNLmgy9zGFJsslKZeX/AL/TrcAF8F3g6cBfA38BPNBHRkmaZIv6DiBJ0oZg6IWlKyvLu8fvAg4EPltVD3X3OtkeeDODsnJ8Vd2QZLNH7WON/7dlkuOTrFgKWZowK59bixcv7juONiL+3pIkadWGWlgeVVZOBZ4NPK+qHuzeu4fBPVFmAN8CbkmyNfDhJKclOR0evj/LalXVmVU11yFLTbSVz62RES/h1cTx95YkSas21MKyUll5D7Ar8OKurGy64r2qWgJ8HPgc8H7gBuB7DO7VsleSjw8zsyRJkqT+DP1O90lmAjsD81cqKw8lOQj4LQbl5N8Z3E1+a+DKqjq9++wrgL9aeaRGkiRJ0sZr6HNYquoWHjmy8lCSw4APAJsBL+nevwM4HTjz/7N352FzlfX9x98fkrC2IJggImq0yiayJewCKgqiFBRBipVCQUGhalEBkS6u0FoEN9QfaEULuCIWaYtYBQU3TBQRUSoKKFQgbCLVGJJ8f3+c8+BjTEJIZuac5Hm/rmuuZ5Yzc39n5n7uOd9zL2fc0/cBHttut0xmzJhBVS3xIknDsrxtj+2WJEm/N/IeFvj9HJQ2WdkCOAU4tqq+nuT1wFOSPBn4bVXd106y/yvgOODQqprbRdySJEmSRquThGURNwHHVdX3k0wDXgn8EHgt8MQkJwL3AzvQJCvXdxeqJEmSpFHq5DwsAEkel+RJVTW3qsbOR7Ad8NaqeiHNeVhuBbauqtuBE01WJEmSpImlkx6WJAfRnGslSS4FvldVF1XVZWPbVNWdSVYDNmzv+m0HoUqSJEnqUBcnjlwPeD3wKuBFwO3A3klesch2BwO7AJfBw597RZIkSdKqp4shYZOA+cB9VXUb8CmaZYy3S7IfQJLDgbcCL6uqGzuIUZKkVdIPfvADkiz2Mn369K7DUw9Mnz59iXVE6kIXyxrfA3wZeHuSDavqbuBy4CfAjHazC4HnVdUPRx2fJEmrsnnz5i1xyexbbrml6/DUA7fccovLqqtXRpKwJNkvyalJzkoyFbgAuAE4Mcljquou4HPAc5M8rqoeqCpbTUmSJGmCG3rCkmQG8CHgW8BawHuALYFvAr8GzkqyGbBz+5T/G3ZMkiRJklYOo+hh2RS4rKourqojgauAvYE1gXOBa4F305x/5TVVdd8IYpIkSZK0EhhFwvJtYOMkuwJU1QeB64CXAvdW1VuBg4F9q+q7I4hHkiRJ0kpiKAlLkm2TbJFky6r6GTAb2D3J5gBV9QGalcJObm8/UFVzhxGLJEmSpJXXwBOWJPsCXwCOAz6d5MXAR4AnAwck2bPd9GqaOSySJEmStFgDO9N9msW51wFeDRxXVRcn2QU4D3gTcBpwBPDmJHcAuwIvGFT5kiRJklY9A0tY2jPRP5BkFrBukilV9c0khwKfBl5XVW9OsgmwHXBiVf18UOVLkiRJWvUMYw7L7cBeNEsYU1VXA4cBb0ryZ1V1a1V9wWRFkiRJ0sMZWMLSDgkbm1C/NvDBJOu1PS1X0ixfvGBQ5UmSJEla9a3QkLD2hI8bALOAhbQJSVUdkuQTNOdX+VaSycCeNCuDSZIkSdIyWe6EJcmBwKnAbe1lVpJzq+p+gKo6NMmRwMbANsD+VXXrAGKWJEmSNEEsV8KSZApwCHBUVX29Xbp4Z+CkJO+sql8BVNW/ttuvUVW/G1TQkiRJkiaGFZnDsi7w1Pb6RcAlwBTgUIAkOybZvn183gqUI0mSJGmCWq6EpaoeBM4ADkyye1UtBK4CrgH2SLIWsBvwv+32NaB4JUmSJE0gK9LDciVwGXBYkj2qakFVXUAzZ2Xjqjqzqm4fSJSSJEmSJqTlnnRfVXOTnA8UcHKSzYHfAdOABwYUnyRJkqQJbIWWNa6qe5OcA1wPHAPMBV5WVXcMIjhJkiRJE9sKJSwAVTUPuDzJ15qbtXDFw5IkSZKkASQsY6rKs9hLkiRJGqgVmXQvSZIkSUNlwiJJkiSpt0xYJEmSJPWWCYskSZKk3jJhkSRJktRbK03CkiRdxyBJkiRptHqdsCSZmmQ9aE7w0nU8kiRJkkartwlLkhcClwPnJDkvybpdxyRJkiRptHqZsCR5PHAS8HLgZcDqwPuSbLmMzz86yawks+bMmTPESDXRWLc0LNYtSZIWr5cJC/Br4H7gt1U1r6peAtwDnJxkbVj6nJaqOruqZlbVzGnTpo0mYk0I1i0Ni3VLkqTF62XCUlX3AVcDM8bNYTkeWBv4YHvbOS2SJEnSKq43CUuSXZP8TZJ9kqwPXAa8CHhmexvgCGC1JGt2FackSZKk0ZncdQAASfYD/olmkv32wIyqOrWdy/LXwEZJZgObAVvSk7glSZIkDVfnO/5JNgPeChxRVbOS7AO8Icn7quqCJHcDM9pt1gaOqqoHOgxZkiRJ0oh0nrAAPwfeC1wHUFVfTPJqmp6Wr1bVF4EvJvkTYEpV3dtdqJIkSZJGqbOEJcnjgNWr6ibg3Pa+Narqd8ACYI32vpnAbVX1y65ilSRJktSNTibdJzkI+BzwqSRvS3IgQJusANwK3J5kf+A0wBXBJEmSpAlo5D0s7TLFrwdeBdwBHAA8N8n6VfWRdrN7gA+314+qqttHHackSZKk7nUxJGwSMB+4r6puS/IpYA7wrCRzqupiYD3g6cBWVfXTDmKUJEmS1AMjHxJWVfcAXwbenmTDqrqbZjnjn9BMtAf4O2BbkxVJkiRpYhtJwpJkvySnJjkryVTgAuAG4MQkj6mqu2jmtDwnySZVdX9V3TCK2CRJkiT119ATliQzgA8B3wLWAt5Dc/LHbwK/Bs5qz8Wyc/sUz7EiSZIkCRhND8umwGVVdXFVHQlcBewNrEmznPG1wLuBVwKvqar7RhCTJEmSpJXAKBKWbwMbJ9kVoKo+SHOSyJcC91bVW4GDgX2r6rsjiEeSJEnSSmIoCUuSbZNskWTLqvoZMBvYPcnmAFX1AZqVwk5ubz9QVXOHEYskSZKkldfAE5Yk+wJfAI4DPp3kxcBHgCcDByTZs930apo5LJIkSZK0WAM7D0uSAOsArwaOq6qLk+wCnAe8ieaM9UcAb05yB7Ar8IJBlS9JkiRp1TOwhKWqCnggySxg3SRTquqbSQ4FPg28rqrenGQTYDvgxKr6+aDKlyRJkrTqGcYcltuBvWiWMKaqrgYOA96U5M+q6taq+oLJiiRJkqSHM7CEpR0SNjahfm3gg0nWa3tarqRZvnjBoMqTJEmStOpboSFh7QkfNwBmAQtpE5KqOiTJJ2jOr/KtJJOBPWlWBpMkSZKkZbLcCUuSA4FTgdvay6wk51bV/QBVdWiSI4GNgW2A/avq1gHELEmSJGmCWK6EJckU4BDgqKr6ert08c7ASUneWVW/Aqiqf223X6OqfjeooCVJkiRNDCsyh2Vd4Knt9YuAS4ApwKEASXZMsn37+LwVKEeSJEnSBLVcCUtVPQicARyYZPeqWghcBVwD7JFkLWA34H/b7WtA8UqSJEmaQFakh+VK4DLgsCR7VNWCqrqAZs7KxlV1ZlXdPpAoJUmSJE1Iyz3pvqrmJjkfKODkJJsDvwOmAQ8MKD5JkiRJE9gKLWtcVfcmOQe4HjgGmAu8rKruGERwkiRJkia2FUpYAKpqHnB5kq81N2vhioclSZIkSQNIWMZUlWexlyRJkjRQKzLpXpIkSZKGyoRFkiRJUm+ZsEiSJEnqLRMWSZIkSb1lwiJJkiSpt0xYJEmSJPVWrxOWJNsm2a7rOCRJkiR1o7cJS5LnAR8FHuw6FkmSJEnd6GXCkmQv4Bzg6Kq6Lsnqizyeh3n+0UlmJZk1Z86cYYaqCca6pWGxbkmStHi9S1iSrAnsAFwP/DzJesAHk5yZ5P0AVVVLe42qOruqZlbVzGnTpg0/aE0Y1i0Ni3VLkqTF613CUlVzgX8DLgHeA1wH3AhcBGyX5GMdhidJkiRphCZ3HcCYJHsAOwHfo0lSPgJsAHy9qt7XbvNS4B+TrFZVCzsLVpIkSdJI9KKHJcneNBPspwL7A+cBm1XVW4Czx226D/BYYPU/ehFJkiRJq5y+9LBsA5xVVWe0c1ZeAnw8yVFVdXU7yf6vgOOAQ9thY5IkSZJWcX1JWP4P2B6gqn4FnJNkIfCWJK8AimYi/qFVdX13YUqSJEkapc6GhCV5XJIntDfPBXZMcuq4TT4P3AQ8vqpuA040WZEkSZImlk4SliQHAZ8DPpvkNJrelX2AXdvbVNXdNHNVtm+f9tsuYpUkSZLUnZEPCWvnqLweeBVwB3AAcBjwVeAvgC8m2RC4F9gd+Gd4+HOvSJIkSVr1dDGHZRIwH7ivqm5L8ilgDvAcmvOt7AK8CHgU8KKq+kkHMUqSJEnqgZEnLFV1T5IvA29P8rdVdWeSy4FNgP2r6mrg/FHHJUmSJKl/RjKHJcl+SU5NclaSqcAFwA3AiUkeU1V30cxpeWaSjUYRkyRJkqT+G3rCkmQG8CHgW8BawHuALYFvAr8GzkqyGbBz+xTPsSJJkiQJGE0Py6bAZVV1cVUdCVwF7A2sSbOc8bXAu4FXAq+pqvtGEJMkSZKklcAoEpZvAxsn2RWgqj4IXAe8FLi3qt4KHAzsW1XfHUE8kiRJklYSQ0lYkmybZIskW1bVz4DZwO5JNgeoqg/QrBR2cnv7gapyKJgkSZKkPzDwhCXJvsAXgOOATyd5MfAR4MnAAUn2bDe9mmYOiyRJkiQt1sCWNU4SYB3g1cBxVXVxkl2A84A3AacBRwBvTnIHsCvwgkGVL0mSJGnVM7CEpT0T/QNJZgHrJplSVd9McijwaeB1VfXmJJsA2wEnVtXPB1W+JEmSpFXPMOaw3A7sRbOEMe2JIA8D3pTkz6rq1qr6gsmKJEmSpIczsISlHRI2NqF+beCDSdZre1qupFm+eMGgypMkSZK06luhIWHtCR83AGYBC2kTkqo6JMknaM6v8q0kk4E9aVYGkyRJkqRlstwJS5IDgVOB29rLrCTnVtX9AFV1aJIjgY2BbYD9q+rWAcQsSZIkaYJYroQlyRTgEOCoqvp6u3TxzsBJSd5ZVb8CqKp/bbdfo6p+N6igJUmSJE0MKzKHZV3gqe31i4BLgCnAoQBJdkyyffv4vBUoR5IkSdIEtVwJS1U9CJwBHJhk96paCFwFXAPskWQtYDfgf9vta0DxSpIkSZpAVqSH5UrgMuCwJHtU1YKquoBmzsrGVXVmVd0+kCglSZIkTUjLPem+quYmOR8o4OQkmwO/A6YBDwwoPkmSJEkT2Aota1xV9yY5B7geOAaYC7ysqu4YRHCSJEmSJrYVSlgAqmoecHmSrzU3a+GKhyVJkiRJA0hYxlSVZ7GXJEmSNFArMulekiRJkobKhEWSJElSb5mwSJIkSeotExZJkiRJvWXCIkmSJKm3TFgkSZIk9VavE5YkmybZKcnkJKu196XruCRJkiSNxsDOwzJoSQ4E3gH8EvgFMCvJuVX16ySpquo2QkmSJEnD1sseliSrA4cCR1XVs4FLgCcCJyb504dLVpIcnWRWkllz5swZQcSaKKxbGhbrliRJi9fLhKW1LvBn7fXP0SQtawIvfbhhYVV1dlXNrKqZ06ZNG3KYmkisWxoW65YkSYvXy4SlquYBZwIHJ9mtqhYAVwHfB3ZzOJgkSZI0MfQmYUmybZJdxt31HeBLwOFJnlFV86vqPODxSbbuJkpJkiRJo9SLSfdJng98HvhoknWq6r+r6u4k/wUUcEqSzwALgGnA7R2GK0mSJGlEOk9Y2gn2OwCnAfcA+yShTVpuTPJvwI+BVwC/Aw6rqju7i1iSJEnSqHSesFTVvCTvB+4DHgv8NbB3ktWq6rKq+hXw30m+Bixo57NIkiRJmgA6S1iS7ABMAn5bVd9v7741ybk0Sctzk9wGbA1cP24bSZIkSRNEJwlLkn2B9wJfBR6T5KaqO9vltQAAIABJREFUeg1AVf0iyUeBA4CzgBnAzl3EKUmSJKlbI18lLMkU4GjgH6rq5cCRwDPaJAVokhaayfWbATtV1Q9HHackSZKk7o08YamqB4HZNCt+UVVzgB2Bpyc5A6A9MeTawAuq6vpRxyhJkiSpH0aWsCRZf9zNn9AsVTwVoKrm0wwBm55ks2qcUFXfHVV8kiRJkvpnJHNYkuwHHJvkDuBK4DzgScB3kuxQVXdV1W1J5gFrjiImSZIkSf039IQlyabAh4CXAtOBpwIfA46iOSnkl5K8B9iQZkWw+4YdkzSmGX24fGbPnr3U51fVcr+2JC3NirRdkrSyGUUPy3zgi1X1NeBrSR5Ps2zxOcARNMPDnghsA7ykqm4ZQUySJEmSVgKjSFjuBXZM8tqqek+7bPG5wCuBg6rqEwDtiSIXjiAeSZIkSSuJoUy6T7JrksOTPKuq7gX+Ctg3yeEAVfVz4BZgz7HnmKxIkiRJWtTAE5YkzwW+QDNf5V1J/gFYHzgd+Mskr2s3nQtMTbL2oGNY1JFHHsmGG27IVlttNZDXmzRpEttuuy3bbrst+++//zI/78c//jG77LILa6yxBqeffvoSt7vpppvYaaedeMpTnsIhhxzCvHnzADj33HOZNm3aQ2V/+MMffug5J510EltttRVbbbUVn/rUpx66/ytf+Qrbb789W221FYcffjjz588H4N577+VFL3oRW2+9NTvuuCPXXXfdI/0YJEmSpKEbaMLSnj9lJvC6qnoLTc9KAc+hmcvyeuCwdkjYW4C3VtVvBhnD4hxxxBFceumlA3u9tdZai2uuuYZrrrmGiy++eLHbTJ8+/Y/u22CDDXjve9/LG97whqW+/kknncTxxx/PjTfeyPrrr89HPvKRhx475JBDHir75S9/OQD/8R//wXe/+12uueYavv3tb3P66adz//33s3DhQg4//HA++clPct111/HEJz6Rj33sYwCceuqpbLvttlx77bV8/OMf57Wvfe1yfhqSJEnS8Aw0YalmWaT/A16WZN2qug44n6Y35RlV9QOaYWAnATtW1bWDLH9J9thjDzbYYIM/uO+nP/0pz3ve85gxYwa77747P/7xj4cex4YbbsgOO+zAlClTlrhNVfGVr3yFgw46CIDDDz+cz3/+80t93euvv5499tiDyZMns84667D11ltz6aWXcvfdd7P66quz6aabAvDc5z6XCy+88KHnPPvZzwZg88035+abb+aOO+4YxNuUJEmSBmYYc1jOA75PM/xr7ar6GfB54KVJdquq+6vqjqq6cwhlL7Ojjz6a973vfcyePZvTTz+dY489dpmfO3fuXGbOnMnOO+/8sMnEI3X33XfzqEc9ismTm/UQNtlkE2677baHHr/wwgvZeuutOeigg/jFL34BwDbbbMOll17Kb37zG+666y4uv/xyfvGLXzB16lTmz5/PrFmzAPjsZz/7B8/53Oc+B8DVV1/NLbfcwq233jrQ97KK2KbrACTpEbLdkrRKyYqcKyJJapEXSLIacDCwE3AjcF5V3Z/k3cBXq+qiFQl4OWKcQzPBf3Wac8D8kCZR25am5+ehTdvHHgU8bjEvNY9mCWaAKcB6wP3AZsD/AL8DngD8SbvNmuNe/x7g9nGvtTGwAFhcl8ZkYHNgbFLJFGDTNrZJwEKaYXZTgQ3asgE2ojmXzW9pht/9H3AnsA6wSfuef9W+v+vb208A1m6fsyZwc3t9kKYCdw34NVfUssa0DTC5qhZ7woMkRfNZf3+AsT1Sffl8jeMPLUscT6yqaYt7YFy7tayvNQyWu3KWvdR2C/6ofg1KX/73lqTP8fU5Nvjj+JbYdknDsqIJy+Sqmr/o7SSTgAOBnWkSl/8AXgfs1Pa4jFyS6cAlVbVVknWBG6rqsSvwerOqamY7H+eSqvrsIo/fXFXTl/DcNwMPVNUfzbxv5wHNATZqP8tdgDdX1T6LbDcJuKeq1ltMTBfQJIr/uchz9gZeXlUvWUyZNwFbV9X9y/gRLJOxmAb5miuqjzEtr768F+MYXhxdvSfLnRhlD0rf30Of4+tzbND/+DQxLPeQsCT7Ap9McnKSwwDaHewpVbUA+Czw9zRntf81sEdXycqi2p3ym5IcDM0Oe5Jl6kJPsn6SNdrrU4HdaHosBhVbAZcDB7V3HQ78e1ve+ARrf+BH7f2Tkjy6vb41sDVwWXt7w/bvGjRzhz7U3n5UktXb13o58LVBJyuSJEnSilquhCXJjsB7gYtohhGdkORUgKp6sO1pqar6TVWdA5xVVT8aVNDLEe8ngG8CmyW5NclRwF8CRyX5Ps1wqwOW8eW2AGYBW9IkFv9UVcuUsCTZKMmtNL1Nf9fGsm772H8m2bjd9CTgdUluBB4NjC0T9pokP2xjfg1wRHv/FOBK4GnA2cDLxvV8nZDkR8C1wBeq6ivj3sd1SW4A9gVcJkySJEm9s7xnul8duKKqzgdIcgXwjXZKyyltT8uewPZVdeai81xGraoOXcJDz1uO1/oG8PQkR1fV2UvZbvpi7rudZj7J4rZ//rjrPwN2XMw2JwMnL+b+ucCWi4upqk4ATljMc75JMzdm2Jb4GXWojzEtr768F+P4Q4OMo6v3ZLkTo+xB6ft76HN8fY4N+h+fJoDlmsOSZAbwj8ARVXVPe99GwH8C/1xVn0ryNOBXVeXSU5IkSZKWy3INCauq2cCtwKXj7rsdOItmpSqq6ocmK5IkSZJWxCMeEpZk9aqaV1XHJrkkyVXAQW3CMpVmaNJqNPPHOx0KBg8tPbtEM2bMGFUoWgnNnj37riUt3zh16tSaPn36iCPSymT27NlLffxhlsxeItstLc3S2i2w7dLSPVy7BUtuu6xbWhFLa7seUcKSZLWqmtdePxl4F83yxR9IMo9m/feDqmrhCsY8MmMnVZQWJ8kSz1Uwffp064+WqlkxfInmL+3BpbHeaWmW1m6BbZeW7mHaLVhK22Xd0opYWtu1zAlLm6wsbK+/E9itqk4DLk+yBc0JCO+uqptXMF5Jmgi6POGoJC0v2y6N3DIlLIskK6fTLJ+759jjXS5ZLEmSJGnVtUyT7sclK++iOf/In487o70kSZIkDcUyrxKW5AnAZsD+Y8lKe0Z7SZIkSRqKZU5YqurnjOtZMVmRJEmSNGyP6DwsY8sUm6xIkiRJGoXlOnHkymTGjBlU1RIvkjQsy9v22G5J6srS2h7bH3VllU9YJEmSJK28VqqEJclKFa8kSZKkFfOIznQ/akleAOwIrA6cXlV3dxySJEmSpBHqbY9Fkp2A9wM3AOsDFyfZNcmUZXju0UlmJZk1Z86cYYeqCcS6pWGxbmmYrF+SVma9TViArYDLquqCqnolcCFwIjADlj48rKrOrqqZVTVz2rRpo4lWE4J1S8Ni3dIwWb80Cj/4wQ9IstjL9OnTuw5PHZs+ffoS60eSpT63z0PCvgPsmWTzqvpxVZ3RJilnJtm3qu7rOkBJkiQ15s2bt8SVxB5uh1SrvltuuWWpK80trY70uYfldmA+8NwkUwGq6nTgOuCYLgOTJEmSNBq9SliSTBq7XlV3Au8D9gEOTfL09qGfAi4ELkmSJE0AvRgSlmTTqvqfqlqQZFL7N1X1vSR/T9OjsluSolk17IXdRixJkiRpFDrvYUmyH3BNkgsAxiUtlWS1qvoe8HfA3wNfAJ5TVT/oMGRJkiRJI9JpwpJkHeBvgL8F5iU5Dx5KWiZX1cJ20/lV9ZN2xbCbuopXkiRJ0mh1mrBU1f8BRwIXAG8A1hyXtMwHSLIN8LIka8YlJiRJkqQJpfMhYVX1v1X1QFXdRTNXZa2xpCXJ1sBTgE9X1dxa2lpokiRJklY5nScs41XV3TRJy4NJbqA5WeQ32hXDJEmSJE0wvUpYANqelmuB9YADq+qXHYckSZIkqSO9S1iSrA88H9jb1cAkSZKkia0X52EZr6ruTfLnVTW361gkSZIkdat3PSwAJiuSJEmSoKcJiyRJkiSBCYskSZKkHjNhkSRJktRbJiySJEmSesuERZIkSVJvmbBIkiRJ6i0TFkmSJEm9ZcIiSZIkqbdMWCRJkiT1lgmLJEmSpN4yYZEkSZLUWyYskiRJknrLhEWSJElSb5mwSJIkSeotExZJkiRJvWXCIkmSJKm3TFgkSZIk9dbkrgNYmiTPAeYDV1bVgq7jkSRJkjRave1hSTIFOA14B7Bjkl4nV5IkSZIGr7cJC03Pyrfav6cAzwBIkod7YpKjk8xKMmvOnDnDjVITinVLw2Ld0jBZvyStzHqbsFRVAf8JvBm4EDg+yWuAv00y6WGee3ZVzayqmdOmTRt+sJowrFsaFuuWhsn6JWll1tuEZZxXV9VHgduAM4G1nc8iSZIkTQy9TFjGDfv6EnBtkl2AvYCPAM9OsmtnwUmSJEkamV4kLEk2S7JLkilJJlVVJUlVzQd2AL4OvKGqjgY+B9zaacCSJEmSRqLzlbeSHAicSjPk6zZgVpJzq+r+dpNDgM2qajZAVZ3VTaSSJEmSRq3THpZ26eJDgKOqai/g34HHAycleRRAVT0wlqwk6UWPkCRJkqTR6EMCsC7w1Pb6RcAlwBTgLwCSzEyyLUBVLewkQkmSJEmd6DRhqaoHgTOAA5Ps3iYkVwHXAHskWQvYHbi9wzAlSZIkdaQPPSxXApcBhyXZo6oWVNUFwMbAxlV1ZlWZsEiSJEkTUOeT7qtqbpLzgQJOTrI58DtgGvBAp8FJkiRJ6lTnCQtAVd2b5BzgeuAYYC7wsqq6o9vIJEmSJHWpFwkLQFXNAy5P8rXmphPsJUmSpImuNwnLmKpa0HUMkiRJkvqhD5PuJUmSJGmxTFgkSZIk9ZYJiyRJkqTeMmGRJEmS1FsmLJIkSZJ6y4RFkiRJUm+ZsEiSJEnqLRMWSZIkSb1lwiJJkiSpt0xYJEmSJPWWCYskSZKk3jJhkSRJktRbJiySJEmSesuERZIkSVJvmbBIkiRJ6i0TFkmSJEm9ZcIiSZIkqbdMWCRJkiT1lgmLJEmSpN6a3HUAS5NkJ2A6cEdVXdFtNJIkSZJGrbc9LEn2Bc4Dng5ckOSwR/Dco5PMSjJrzpw5Q4tRE491S8Ni3dIwWb8krcx6mbAk2RT4Z+Doqvo74DDgLUk2XpbnV9XZVTWzqmZOmzZtmKFqgrFuaVisWxom65eklVkvExbgfuCNVXV5kslV9WXgeiAdxyVJkiRphHqZsFTV7cA32uvzxz20IUCSLZKs3UVskiRJkkanFwlLkix6varua2+PLQzwJ8D8JC8BPgasOeo4JUmSJI1WX1YJmwTMB6iqSrJaVS1sH1vQ/v0e8EZgE+Coqrpn9GFKkiRJGqXOE5Z2NbCjkswGbq2qf6uqhWNJS1VVu+k6wPOBnavqhs4CliRJkjQynQ4JS7Ij8F7gIuBm4IQkpwKMJS3jNv8AsJ3JiiRJkjRxdN3DsjpwRVWdD5DkCuAbSaqqTmmTlmcCT6uqszqMU5IkSVIHup50/1vgMUk2AKiqXwK7APsmOaTdZg5wcUfxSZIkSepQpwlLVc0GbgUuHXff7cBZtEsYV9UPq+oX3UQoSZIkqUudJSxJVgeoqmOBO5NclWSj9uGpwMwkq41f8liSJEnSxNLJHJZ2BbB57fWTgXcBBwIfSDIP2AY4aNzSxpIkSZImoJEnLOPPsZLkncBuVXUacHmSLYC1gbur6uZRxyZJkiSpX0aasCySrJwOPA3Yc+zxqvrRKOORJEmS1G8jncMyLll5F7Al8OdVNT/JpFHGIUmSJGnlMPJJ90meAGwG7D+WrFTVglHHIUmSJKn/Rp6wVNXPGdezYrIiSZIkaUk6Wda4qqr9a7IiSZIkaYm6PtO9JEmSJC2RCYskSZKk3jJhkSRJktRbJiySJEmSesuERZIkSVJvmbBIkiRJ6i0TFkmSJEm9ZcIiSZIkqbdMWCRJkiT1lgmLJEmSpN4yYZEkSZLUWyYskiRJknrLhEWSJElSb/U+YUmSrmOQJEmS1I3eJyyACYskSZI0QU3uOoClSfIs4IVJrgEuqqr7uo5JkiRJ0uj0toclyd7AOcAtwPHAXo/guUcnmZVk1pw5c4YVoiYg65aGxbqlYbJ+SVqZ9S5hSWMt4KXASVV1BnAmsH2SZyWZ/nCvUVVnV9XMqpo5bdq04QasCcW6pWGxbmmYrF+SVma9S1iq8Vvgp8ArkjwDeDcwFXgjcGySbbqMUZIkSdJo9C5hGbcq2CeAa4BXAWdX1THt9U2Ap3UUniRJkqQR6kXCsrili6vqxqp6I3AhsE6StavqZ8BNwFOX9DxJkiRJq46+rBI2CZgPzZCwJJOqakH72PeAZwBvS3IzcDCw39i2HcQqSZIkaUQ672FJsi/wySQnJzkMoKoWJBmL7efAV4G5wAzghVX1P91EK0mSJGmUOu1hSbIj8F7gzcBC4OQkW1TVm6pqYZIpVfUg8O/AvydZvarmdRiyJEmSpBHqekjY6sAVVXU+QJIrgG8kqao6paoeTPJMYLuqOhN4sLtQJUmSJI1a10PCfgs8JskGAFX1S2AXYN8kh7TbzAE+0z7unBVJkiRpAuk0Yamq2cCtwKXj7rsdOAvYsL39w6q6tZsIJUmSJHWps4QlyeoAVXUscGeSq5Js1D48FZiZZDWXLpYkSZImrk7msCRZbWzyfJKTgXcBBwIfSDIP2AY4qKoWdhGfJEmSpH4YecLSJisL2+vvBHarqtOAy5NsAawN3F1VN486NkmSJEn9MtKEZZFk5XTgacCeY49X1Y9GGY8kSZKkfhvpHJZxycq7gC2BP6+q+UkmjTIOSZIkSSuHkU+6T/IEYDNg/7FkpaoWjDoOSZIkSf038oSlqn7OuJ4VkxVJkiRJS9LJssZjJ4A0WZEkSZK0NF2f6V6SJEmSlsiERZIkSVJvdXLiSKkvkiz3c2fPnr3U57cjHyVp4IbVdtluSeoje1gkSZIk9ZYJiyRJkqTeMmGRJEmS1FsmLJIkSZJ6y4RFkiRJUm+ZsEiSJEnqLRMWaem26ToASXqEbLckrVKyqq+5nmQOcMsQXnoqcNcQXndFGNOyWdaYtgEmV9ViT1iQpID5wPcHGNsj1ZfP1zj+0LLE8cSqmra4BxZpt7p6T5a7cpa91HYLhtZ29eV/b0n6HF+fY4M/jm9Z265R6cvn15c4oD+xPNI4lly3VvWEZViSzKqqmV3HMZ4xLZs+xrS8+vJejGN4cXT1nix3YpQ9KH1/D32Or8+xgfGtbHFAf2IZZBwOCZMkSZLUWyYskiRJknrLhGX5nd11AIthTMumjzEtr768F+P4Q4OMo6v3ZLkTo+xB6ft76HN8fY4NjG9Z9SUO6E8sA4vDOSySJEmSesseFkmSJEm9ZcKiziVZ4vKbfdD3+FYGfoZL5mcjSdLSmbCoD9ZL8lBd7MMOXJLHJZkOUFXVh5gGpaP30ovvOMlTkqzeRdmLxLFS1a++xzcISdboOgZpWUyE/8fl5Wez6jJhGZEka3cdw3hJtk2yb5LHdxzH/sCXgPcneR80O3Adx/R84L+As5N8rg8xragkOyTZC0a/g9yX77hNEP4HOCbJeqMuf1wcy1W/Ov4h/pNRFNK2S1sk2WIU5Y0r99nAy7tOZscn9auqJJsm2SnJ5LH324edzLbubdd1HEuSZOpYu9XH36MefX6d16WuJXlOkmcmmdR1LOOtaPu2yjeOfZDkAOCfkmzYdSzwUDznAccB700ykp2RxcSxKfAO4I3AO4Gtk3w6yZrt4yNveJLMAP4JOAbYB5ifZN1RxzEoaWwAXAK8IckL4aGkZeiNWc++43nAz4D9gJd18b0ub/1KsgdwUpL9R32QIcnzgI8nWWeY31eSfYEvAMcCn0ny18Mqa5Fynwe8G7i2quaNosxxZb8gyVuSnJbk0VW1cJTlj1qSA4F/B04DPgIcl+RPu+5lbOvAR4EHu4phadp2+3LgnCTn9e03qS+fX5JnAWcm+eskj+owjp2SHJLkmR2UPYXm/+sdwI5JJo86hnGxDLR9M2EZsiR7Av8MXFJVdy7y2Mg//yRPAE4AXlJV+9HUge2TrDG2AzvCH45f0xzx/n5V3VxVewKTgH+Dzo4iBfhyVX0TeBywO/AvST45dvS1D0cDl1U17gEuBK4CnpXk4PaxBSMIoTffcVX9L3BOe3kxsH/7w/LUUcXActSv9uj/54D5NInO8Un+YiTBNknE3wMfqKr/G8b31SbVfwK8Gjiuql4NvBw4JckrB13eImVvDXwCeGtVXZnk0e2R7CcNs9y27J2A9wM3AOsDFyfZtd3hWOW09ftQ4KiqejbNQZQnAieOJS0dxbUXTZtwdFVdt2gvW9ftfXuA4iSa/4mXAasD70uyZZdxjenL55dk7zaOW4Djgb1GUe5i4tiX5oDw04ELkhw24hDmA99q/54CPKONa6T1eBjtmwnL8O0AnFNVlyV5bJK90gzP+dOqWthB0vI74DfAn6YZprY98HrgX4G/SjJlhD8cvwF+BcwYu6OqXgw8JsnpI4phUXOBpyV5N/A14D00vQNrA59pY+xdd/ySjGuk7gDWAX4APCPJCUmOa7cZZk9Lb77j9kjTk4AHgIOA1wFfB54wwjCWp349CXhzVZ1O0/vwPeDZw0xa2iRiOvAfwHur6ktJNm5/cHbNAOd7tEn1A8AsYN22DfoW8Bc0vUpHDKqsxVgT+DSwUZKZwPnAu4AvDrlcgK2Ay6rqgqp6Jc1BhRNp/1e6OKA1AusCf9Ze/xxN0rIm8NIuEoM0Pb07ANcDP08z5OqDSc5M8n7oRXv/a+B+4LdVNa+qXgLcA5zc/oZ3OSew88+vbavWAl4KnFRVZwBn0hyIfVbbjo1EmhEF/0yTvP0dcBjwliQbjyqG9vP+T+DNNG3K8UleA/ztkH/rFzXw9m1VbBB7YVwDMh8Y6wa7EHgF8FrgA0nWG+UQgCSTquoO4DLgX4Bv0Bw5PQD4CvBsYIMhx7BHkjckeS5N/fsUcFqSHcdt9kpGWDfbmE5I8hyaozPH0Ow8fptmZ+3eqtofWD3Jo0cV1yCM+7H4KvCLqvowzdCot9J+14PuaenLdzw+jiRPrqr5NEfTH0Wz4zQNuBaYnuRPhxzHitSvBcCRSdavqlto5r9cCczMkIaZtknEzTQ7729KsgPNzvzhNAc3js/g5wHdTnNUdK02hlk0P/h/M6wej6q6Gvg48BTgv4GLgaOAI4G3J3naMMptfQdYK8nmbSxn0PSCnpnkUava8LB2uN2ZwMFJdmvbnauA7wO7dZEYVNVcmt7eS2gOHlwH3AhcBGyX5GOjjmlRVXUfcDUwI7+fw3I8zUGOD7a3O0mq2s/vY3T4+bVt1W+BnwKvSPIMmiGeU2kOBh2bZJthx9G6H3hjVV2eZHJVfZkmmesioXx1VX0UuI3m/27tEY2qGDPw9s2EZUjGNSCXA69K8gng7Kr6C+AfaY4877ik5w9SmnHvH6JJkrZuj9S+hOaI5tfaeD8CbEjzwz2sOPamGec6Dfhzmp22G4C3t7Htn+SxwK40O2NrDSuWxcQ0FTiApqF9TFV9neZI/Dbtdi8BHk1PxziPN/Z9Jzk7v58EeQvNkf0DaYZDfQR4QpoJ8YMsuxff8SJxvIBm7PfOwE3A6cA3gb+i6Wk5ABjKMJxB1K+qOhf4Mk3isF5V3UXT8G8PDGWS69jRr6o6AbiUJrm6qKqOoWk7DgJ2GlBZacv6AO1OWJL12p6Wq2iSymEMRRt7j1+nSaqPamNY0JZ7KU2P9LDcTnNA67lJpraxnE6z03fMEMsdmTQTsXcZd9d3aBbgODzJM6pqflWdBzw+zfC8UcU1/iDCApr28EfAO6vqtKr6Gs0R+wVd9HS1vZh/k2SfJOvTHGR8EfDM9jbAEcBqbS/HqOPbM8kpSQ6hqcOfpqm3/zzqz2/cweFPANcAr6LZ1zqmvb4JMMwDDw+pqttpDgTTHiAbs2Eb6xYZ4gJM4z6LLwHXtv97e9HU72cn2XVYZS/GwNu3zibjrKqSbAus1Y5Rp6q+n+QEmqMPP2rv+2nbNTdtBPFsR7OD9npgc+Dfkrytqj6b5HJgnyQP0PxTTwNuHmI42wBnVdUZ7ZGiQ2iOaO4PnEyzI31kG8uR7VGTYVs0poNpdm4PpvmRODvJ92jGox5WVfePIKbltsj3vRnwsSRvozkivwbNkZZXVdV/JjmcJmkdpL58x4v9Xml+9E8GflVVlwMkOWTUcSxH/fpM+9y/T3JqVd2U5Ds0Bxi+OIhAk2TsQMvYcNWqWlhVJyW5pKqubB+7NsnXaHqplreszWh6+GbR9EAvaF/7kPbgzruBb6UZxrcnzQ/fCltMubTlfjPt2PuqqnZHbDtgoPUiTS/32Hu9M82qeW9rH7uiqn5Ac6S462FIKyzNanifBz6aZJ2q+u+qujvJf9G8v1OSfIbmu59Gs4Mzirj2pumZ+CxNu/RG4ISqekv+cKjjPsBjaeaMzB1FbG18+9EszHE5zUGJGVV1apq5LH9NM3xxNk37viUj3o9LM0fjn2i+2wOAdarqX9MMAfvNuE2H9vmNb6vGVNWNwBvbg3LPSbJ2Vf0syU3AU5f0vEHFMXa97RGj7WGZT7PC4vz2oNQbgOfxh5/TipT/B+1ZVS1o45ifplf8H4ADquoLaYaA3zqIcpcSz3Dbt6ryMqAL8Hya4Tb/D9hr3P1r0+yk/YzmqMiRNBXsz0YQ0/7AZ8bdfjHNkJI/p9lJehdwBc0O7dZDjuVY4MOL3Hc0zXjL9drP6dE0R6BH9Z0tLqZXtDGtTrPDORN4Ytf1azm/7wPb9/Lc9rLnuMcmr6rf8VLi+C/gce3t1Wi66tP3+tXGOZNmKOcPaH4E7gSeOsBYJy9yezVgtcVsdxjNUbInL2c5BwI/puk1+jjwGmDdRbY5Evg7mkTtaQN6f0ssd6wO0Oz8/RVNr85Aym1fd9Nx1yctUuZ2wIeAT9IcJf7X0ShWAAAa2ElEQVQp8PRh1clRXNq6/Y/AW2iGQP8L8Jxxj68HPIemZ+vjwHYjjO0E4HXj4nhF+z+149j3QjP08fvAliP+3DYDvgvMbG/vQ3O0/E/H3X5T235cAWw74vi2oOnd3a29/XrgVODJwGNH9fktpq2aNO76k4AzaPZtXk2z6MumI4pjtXHXx/6/z6QZTvvVQf5fP1w7SpMozRhRvRhJ+zayir6qXx6ugW632YFmubl3j+oHCXg8zRjdGeMq0EE0P8ibtrc3BKYOqfzHAU9or6/dlnvquMcf3VbmXUb4XS1LTP9vlDEN+ft+yfgfD9od9VXtO16GOKbSHFndtY/1iyYhediDGDS9Vi8BNhtgzPvSHHE+maanZ+z+8T/Aa9AcHfwRy7kzTzP07lP8fofnxW1b+Q5gvcVsv8aA3t8yl0vTC/eUAX62+9EcUb1g3H1jP+qrjaubT6UZRvOkYdbPUV3aej6Jpjf172mWNd97kW1WZ9zO5ojiWtxBhKNoDmZs0v7/vp8RJyttHGvRHNRcc9x9lzDuQFN7358A63cQ35rANu31acBPaHpa3tP+3RTYaJif38O1VW2dO6D93z63qzjG3T4buHfA7fXS2rNHLWb7PzrwNMBYRta+jbSyr+qXZWygh3Y0d1wZOwA70/aYtHGcRrMzO1aBTqFZzWKYR5cPohn7fnVb/jNouoivAE4bt92HgWNH9B31LqYRfd9vohlfvEp+nit7HDS9XwtpFuYY2M7yMsa8I82Ox1/SLDu7aII1PmmZRttDtZxlTaHZMTxi7LVphny9E3jluHi2b68PpH16BOVuMeDPdh2auTBH0+w8nTfuscnjrv/RTsbKeBnXFm2zyP2Ppxme8i808wkOXXSbIce1LAcRPkB7EIFmgvIoP7fHsciOHG2yTnPemr3b6zNpezJ6EN/etDvqNAc93w8cNMzPbxnaqimLbL96R3GMbzO3BaYPuPxlac9mMuQeuFG3b0N7IxPl0rcGmibr/wnNDtF/0PT4TGor02njGuTXAmcMMY71aCY2b982dsfSHFV+Kc0RmO/TTAQ7nWZS9sCGtqxMMa3M33dfPs+VPQ6ao6on0QxFOp121arFvP5ejEt6Bhj3M2iWXh+7/ViaxQneMe6+Z9KsOjOI8p5LM69p9/b2pPYzuqD9LI4HNhrC+1yWcge+MwhsTHNEfCrNEdnzFnl8G+BvaI5eD/2A1rAui7RFX6BZAW/8449v3+cVNEv1DmzI3cPE9UgOIhzXXh/Z97BIfG8DDlzk8bOArWmG+35pGP8bjyC+twIvWsJ2H6A9CDOsz+8RtFXH9ySO44b4vXTSji4mjpG1b0N9I6v6pW8NNE3WfRFwaHt7Q5rM//S2Mr+jrcyX0AzrGFoCRTMR7Erace40R7AOptmB25HmKNdfAscxoq73Psa0Mn/fffk8V4U4aMZdjw3h+yDNUqGbLrLNugxhLhXN8MGLgQ3G3bcRzVj6Q9rbTwMeP6Dy1mzbxbOBPcbdfwVDnNfXVbmLxPBoml6089rbW9MM59hwFOUP8X0t2hZNa+vPRxfZ7i3AL0fY5vfiYMYjjO+DNCvWjW3zNppk4WpGPLdpKfG9YpHtDqY5P9RQe4cfQVu1SU/iGEibuYQYOm/PFhPTUNs3VwlbTmnO1nk08A9V9Ykk02hONvbRqvprgKr6RXv/ZsBOVXX9MGOqqgfb1UPGr9KwPc0E/1Oq6pQ2nm2AG6rqF0OM5Z4kX6Y5l8HftrFcTjNcbv9qzn9w/rDKX1liWhFdf999+TxXhTiq6qZx11+V5P/RrKJ0LPBC4DdVdRHNOv+Djnt2kltpuvZ3bO+7PclZtMtxVtUPB1je3CTn06wUc3Kadfp/R7OT+8CgyulLuYvEcHeSY4B/SXIDzVCOParqzlGUPyyLaYvmpDnv0reSnFFVr2uXXF0beMGwfwvHmUSzwtx9VXVbkk8Bc2gm/N8I7EIzZ+lRND0HPxlRXA8X37OSzKmqi2mShqcDW1XVT3sU335VdUm72uQbaYaD3TjMYEbdVvU5jj60Z4uJaajtm+dhWU5V9SDwBw00TcV9epIz4KE1sYfeQOf367JD0+NzSn6/7vV8mvNQbJ/kqVU1p5rlJQeerCTZL8mpSc5qy7+A5qjViUkeU835Iz5Hs5b8RoMuf2WJaUV1+X335fNcleLIuLMPj3231ZxD4H9pjm6e2r7mMOIfW8r3WODOJFeNi3MqzblyVmvbsoGpqntplpl+J80Ja58FvKyaE9sOTVflLhLDXTQ9oevRDP/55ajKHrRlaIsOoDkx62bVOKGqvjuq+KrqHppVlN6eZMOquptmueAf0xxE+E1VnV9VZ40wiVqW+H5C06sBzWp523aQrDxcfDPazS4EnjfsHfSu2qq+xtHG0Hl7tpiYhta+mbA8Qn1roNOs2X5+ko8mOZKmW/4TwHfGxXUbzTrowzxh0QyalaC+RTN+8j00a8R/k2Y43Flp1gzfuX3K0Ne172NMK6rL77svn+eqFEeac50saK+/jebkXmMJzE9ohpU+fxg7U23Z89rrJ9MsA/o9mhN8fpJmtaJ3VnMulhp0+VU1r5pz4fwlzTl5vjfoMvpU7pj2N+T5NBOpfzDKsgfpEbRF82iGr/z/9s40Sq+qSsPPGxLCkAZEBJkEA8rQCBEEhEgio9Bq1AALacDE4ISIAyqI7XLABhREwCGCMshqAmjo4IAYyUJsQAZRICGQNIpECDJohMaIEgNv/9inyGdZlaqkvuFU1X7WuqvuPffce9871D7fPsM+bdNVQ2VGE/QdIGkL20/bbkmFxQD1HShpc9tLbf+uxZo6aqtq09FIp+1Zd1pp39SmZzokKAb6/cDjRF/1y4ATiVk7dy//yJQP9wzbc1us55XAT4n+uFsTYeO2JUI0ngC8nfgRtTHxj3RIqwyLpCOBA21PK9vHEc3Ys4l+wlOI5ve1gI+2o5atRk0DodPvu5bnOVR0lMLv+bJ+JtFCe4Bj0q8NiFmaf2R7Xgu0d7/2eNvjy/YOhLO7xPaiZl87AUlr2a6+gqQ3Om2LVqJrNyKqVldXytHEXD7PEP+LryIiZI4rOt/kMtFfO0h9q6WpCltVi47BQMvsmzswMGcwLkR88cXABCKaz+eJ2qR1iAg/dxGG+STgPtow0SAxWdNFDdtdkclmEIMgJxORImYQ/V9brWU2DXNcEEbvSlZMzjaGhvjybXo+VWkazO+7luc5FHTwj2Evv0SEqBzZuI9uITqbqLvXa+eSS3+WTtuileg6Eri4Yfs4InrVJGCrovHHlFnkO/DcUt+q6anCVtWiY7gv2cLSTySNJQYyH1u2twTeSQyon0rMHL8VEfv6DNvz26DpRcCNxCRY55W0lwHvA+6xfUVJe6FmoMnXH0cM8pLt+ySdRgwK/r7thSXPZcDDtk9p9vUHi6Zm0Yn3XcvzHKo6JJ1NzB49ydGysoZLF7FW08lrJ4ObTpc9K9E1lviBfartW0ra+4mKxvfYflrSGGC5O9DClfpWW1cVtqoWHcOVHMPSf54E9pD0IYgIYMRcF78jomPMsn0OMZFSy5wVSXtLmiJpX8eAq3cAhygidWD7oaJpYtcxLXJWDiFCOR8PfFfSoUR4yLHAWyR1Xf8XRH/+llOjpoHSyfddy/McqjrKD7zt6Iyz0rFrJ4OTWsqeHnSNk7SDpB1t/5YIhrOPImoStqcTka5OKdtL2/xjO/UNTF8VtqoWHcOaTjfx1LwAexP90Pct268muoBMacjzXuD8Nuk5EFgCfIaI9/1pIjLEAcB1wIkl3xRiAp+mzzYLiOjmci3xjwvRt/UB4AiiP/NniSbjK4GHaHHs+Bo1Deb3XcvzHA46WDGOcI0OfF8du3Yug2upoezpRdchwMPELOvziTkfxhJzrZwMTCz5Pgh8sgPPLfU1R2cVtqoWHcN1yS5hvSDpQOLHx1eIyF/fA24mWqVOAmbb/nKpXXoz8A7bz7RQj4hY57+3famknYj48WsTBcYSYobsucQMq5PcgsG6DXpOBe4HvuOIwb8H8F2i4JolaQvCwZvrqHlrOTVqWl1qeN+1PM/UkSSdowZb1IumdYn/v/Nt/0DSXkQgnE8SM7NPJVp7HicqH9/oNkVlS31J0nzSYemBGg100fVBwjk61NGXdCxwNPC87f+UtF7RaLd4IrLSr3V34EO2ny5p+wDnEDO9tj1mfI2aBkKn33ctzzN1JEln6bQtWomuqisRUl+SNI8cw9IDDi/uL8DRktZzjEmZQcyj8LpSyzCRaDLdox3OSuEywkk6StI6jv6m3wP+XdJ4R7z2x1tZYBRnDke/1nWAb0haX9Io2zcREwa1tV9njZqaREfedy3PM3UkSTV0vOzphceA/QlnCdu/AI4BPilpG9uLbf+wgz+2U1+SNIl0WHqnowa660dSN54C7iBi3k8tztQ8otVn41boKFq2k7SXpFE0fDO2jyjb5wLTJB1POHLLW6WlZk0DodPvu5bnmTqSpLN02hb1h9orEVJfkjSf7BJG/PO624OQNAI4HNgT+A1wWWkKPxf4H9tXt1jTSNvLu28rZsGeTMyevSfwI2Lyyj2LU9VsHZOB04FHyvJL4NtdXWJKnmnAZsAuwGdt39tsHbVrGiidfN+1PM/UkSSdp5aypwdd2wEbEv+Pz7shQpOkK4geELcBI4uuibYXt1pX6kuS9pAOC/UZaEX41GOJ8IKLbf9XSR9V+pmKaMI9ipiJ9nrbC1qgYxTR0vQV2z9XhHF9LbAMONP2/3XLP9r2s83WUbumgdLJ913L80wdSV9Iuhh4E/CE7Z2acL7ngK5BxA/ZntTP47YHLgF2Jebm+lIv+T4AfBjYBniJ7T+W9LcQEw8/T7TMfdj2zWXfmcAbiVa8OcR4qV4L6d6usbrUUvb0oKvqSoTUl/TGILRbLycCTr2YsAPH2F4maSpwFvH9AHzN9oXlmC8Sdgvg87a/U9L3IybaXLOc69jy2/pFwMWE3fobMM39mQ7EFYQq6+RChPW7iogxfkxD+qjyV0ST6buBDwA7tFjPHsCviQLhSKJp9vSG/SO75VcLtYwiZnSdWrZHEN1fzgTe16B311ZrqVnTYH7ftTzP1JFLP97NBKKwnd+k8y3tR55FPaRtTARfOA342EqOfTUR8noRsFFD+piu7wbYGVhY1vcGfg6sUZZbgdf3oa/Ha6zm86im7Ol2nVHAd4DxZftQ4ofTacD6PeQf3ebvMvXlsrLnP9js1neBt5f184HjyvpUwknpnv+NROXKSCLy3B3AeqXsfBh4Zcl3KuGwUL6/z5T17YmKjz7vfViPYVFExPgKcDVh8D8u6XQAR23SSAfP2P4W8HW3vjZpTeBntmc4Zgt+A3CkYkZtHN7pREkfKdstayKz/Xfgy8BkSfs4JgG7GbgbmCBpbWA88PtWa6lZ0wDp6Puu5XmmjqQvbN8I/KkxTdI2kmZL+pWkm0otYqt1PGH7DuDvfeS7y/aiHtKXNnw36wJd6wbWImzCaOKH5uMAkg6SdKukOyXNVMw23us1VpNqyp4eWI8YPwNRXl9DPJ8jIcpySbuW/cvaqKuL1Jf0yGCyW6UFdT+iEh/gUuCtfZx6R+BG28tt/4Wo6DiYaKFZZvv+km8O4Sx3HfPTomshsLWkTfq6h2HtsFCngf4rsImkDcs1HyUmqTtE0hElzx+BmW3QAnATMbDyGEkTbD9n+3Ki6Xgz2+fYfqxNWmrWtLrU8L5reZ6pI1lVvgmcYHs34GPA9FU4di1Jv5R0m6S+CuWmIultkhYS3YynAdi+lZh89NGy/MT2AkkbAZ8CDrC9K9Gd58QWyKrBFv0TtVcipL5kNajVbr0YeMorhkgsBjZv2H+opHmSrpK0ZUmbCxwsaZ1iq/YFtiRsxUhJryn5DivpXcdMhhcaDrYCtuhL3MjVv68hwQsG2vafbD+qmDzpWknzHP3w2mqgbf9K0mJgNtFEj+3HJH2dEo3FbexbavtvkmYQtX+nlJqAZ4GXAEvbpaN2TatLDe+7lueZOpJVobQy7A3M1IrAVqPLvslEF4TuPGL7DWV9K9uPKOYU+amke2w/UP73xpc8m0m6u6zPtH1aM7Q7grZcLWkCMZ7lAEnbAjuwouCeo5jnZ32iRvLn5T7XJLqLNZUabNFKuAnYjqhEUKm1vlzSeyiVCB3S1UXqS/rFILZbPwSusP2spPcSrS/72b5O0u7ALcAfCNv0nG1LejtwjqTRRCVgV6CHLwDnFY33AHfRj6h0w9phqc1AS1rT9jLb75d0jaSbgcNKbe5GwI6K6GVuZy2I7SclfQu4D3gvMUjqaNuPt0vDYNC0qtT0vmt5nqkjWQVGELWB47rvsD0LmLWyg20/Uv7+VtLPiPEgD9g+viuPpEU9nb9Z2L5R0thSM/k24DbbS8u1f0y0cCwA5tg+slU6arJFPVF7JULqS1aBmu3WEmADrQhEtQVlkL3tJQ35LiTGdXZpOo0YG4Oky4nJSLtajfcp6QcBryzpTwPvLOkCHgT6DGQ1bB2W2gy0pBG2l5X1U4CziSaz6ZKWEZE7DivNuW2naLtB0o2x2RkdtWvqLzW+71qeZ+pI+oMjzPyDkg63PbMUfDvbntvXsYooNc+U2sKNiJrJM/s4rCmUlpQHSg3krkTt6hLgIeDdks4ggr1MJOb7uQ34uqRtbf9G0rrA5l7RN3ygeqqzRT1ReyVC6kv6Q812q9ikG4juW1cCU4Dvl2tv6ugmCjCJqEhBEU13A9tLJO1MBBK5ruzb2PYTpYXlZFY4NRuU+1gGvIsYA/NCxLreGJZhjYuBfr6sn0IUCJOJvnqNBrotrSvd9JxJRPMYX7Z3IKKULXHzBlcmHSTfd5KsOoq5Il5PVCg9DnyGGLj5DWBTYhDxlbZ76lLR/Vx7AxcQoYVHAOfavqiHfItsb90t7aXEOJL1yvFLgR3LD5FrgXfZ/r2kDwInAS8FngCutf0uSScD7yAGv/4V+Ljtm0vBP52IKmRgtu0TyzX3A75I6ToCfMr2D3q7Rl/333Avg9IWlWdVbSVC6ku6GIR2ayzhrGxIdNU6ujhIZxCOynIiiMBxthdKWgu4s1zmaSKa5t3lmmcRIZ1HAN+wfW5J34voUmbgXiJ62JN93v9wc1hqM9Dd9HwJ+FfgzW6YFyYZOuT7TpKkBtIWJUkymBhWDkvNBlrS2cSAy0kuk1a6YSbaZGiR7ztJkhpIW5QkyWBgWIU1bnBWziairrzZK2a07xiSXkZE8MgCYxiQ7ztJkhpIW5QkyWBhWLWwwAsGejrw1poMtCSVAU9V6ElaS77vJElqIG1RkiSDgWHnsEAa6CRJkiRJkiQZLAxLhyVJkiRJkiRJksHBsBrDkiRJkiRJkiTJ4CIdliRJkiRJkiRJqiUdliRJkiRJkiRJqiUdliRJkiRJkiRJqiUdlqRjSDpc0r2Snpf0ml7ybCnpBkn3lbwfati3oaQ5kn5d/r6opB8laZ6keyTdImmXfmg5TdLDkpY27w6TWpB0lqSF5bu4WtIGveTbQNJVJe8CSXs14dqzJT0l6ZqBnitJkqFLP8vEtST9QtLckvdzDfsuKunzih0bU9InSLpT0nJJh/VTy8WSnpA0vzl3lyQDIx2WpC1Ier2kb3dLng9MBm5cyaHLgY/a3hF4LXC8pB3Lvk8A19t+BXB92QZ4EJho+1XA54Fv9kPiD4E9+nMvSd308q3NAXayvTNwP3BKL4efB8y2vT2wC7CgCZLOAo5pwnmSJBkiDKBMfBbYz/YuwDjgYEmvLfs+YnuXYuceAj5Q0h8CpgKXr4LEbwMHr0L+JGkp6bAkHcP2Atv/20eeR23fWdb/TPyA3LzsfgtwaVm/FHhryXeL7SdL+m3AFl3nk3R0qZ26W9IFktYox9xm+9Fm3VtSF7avs728bP7DN9GFpPWBCcBF5Zhltp8q+7YpLSW/knSTpO1X4drXA38e8E0kSTKk6WeZaNtdPQFGlcVl39MQc80BazekL7I9D3i++/kkfVzSHaVV5oXWGts3An9qwm0lSVNIhyUZNEjaGng1cHtJ2qTByXgM2KSHw44FflyO3wE4AhhvexzwHHBUCyUndTKN8k104+XAH4BLJN0l6UJJ65Z93wROsL0b8DFgenukJkmS/COS1pB0N/AEMMf27Q37LiHKw+2Br/ZxnoOAVxC9C8YBu0ma0DLhSTIARnZaQDK0kXQ7MBoYA2xYjCzAybZ/sgrnGQP8N/DhrlqkRmxbkrsdsy/hsLyuJO0P7AbcERVQrE0Y/GQI0J9vTdJ/EN0MZ/RwipHAroRjcruk84BPSPoisDcws3w3lOsgaTJwag/nesT2G5pzZ0mSDBWaUSbafg4YV8biXS1pJ9vzy753lp4DXyUq6C5ZyakOKstdZXsM4cCsrEtaknSEdFiSlmJ7T4j+usBU21NX9RySRhHOygzbsxp2PS5pU9uPStqUBudD0s7AhcAhtpd0JQOX2u5t/EIyiOnrW5M0FXgTsL9tdz8eWAwsbqitvIoYFzUCeKq0ynW/5ixgVvf0JEmSnmhGmdhwrqck3UCMNZnfkP6cpCuBk1i5wyLgDNsXrK6GJGkX2SUsqZrSF/ciYIHtL3fb/QNgSlmfAny/HPMy4kfkMbbvb8h/PXCYpI1Lvg0lbdVK/UkdSDqYKLwn2X6mpzy2HwMelrRdSdofuK+06D0o6fByLvUn8lySJEmzkfSSriiHktYGDgQWFru0bUkXMAlY2MfpfgJMa4gmtnlX+ZgktZEOS9IxJL1N0mJgL+BHkrq67Wwm6dqSbTwRYWm/MlD+bkn/VvZ9AThQ0q+BA8o2wKeBFwPTS/5fAti+D/gUcJ2keUTkqE3LNc8sWtaRtFjSZ1t790mb+RrwL8Cc8k2cD//0rQGcAMwo38c44PSSfhRwrKS5wL1EwId+IekmYCawf/m2sqtYkiT/RD/LxE2BG4qNuoMYw3INpQeBpHuAe0q+U8vxu5fzHg5cIOleiGAkROSwW8txVxF2EklXALcC2xW7dWwbHkGS9Ip67hmRJEmSJEmSJEnSebKFJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSavl/U066cwU5mTYAAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 849.6x849.6 with 25 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 26
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAywAAAM5CAYAAADllbW1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzde7RdZX3u8e8DCYgiIM0GRY3bFoEAEiCRcinBFkWoGgtiESunERxgtdrWKh70tPV4LJwqihdQD1aKVaCihQq2RbRFuQjqTiWAFi+oICgQLKBBQ4D8zh9rhgbIzey913yT/f2MsUfWZa45nxXm2Obxne87U1VIkiRJUos26TuAJEmSJK2OhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1a1rfASbbjBkzanR0tO8Y2kAtXLjwrqoa6TuHJEnSVLXRF5bR0VHGxsb6jqENVJKb+84gSZI0lXlJmCRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkbfWG5/vrrSbLKn9HR0b7jqQGjo6OrPUckSZLUr2l9B5hsy5Yto6pW+Z7/IBXAzTff7DkiSZLUqI1+hEWSJEnShsvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSs6Z8YXnzm9/MLrvswh577MHhhx/OPffcs8rt7rnnHo488kh22WUXZs2axdVXXz3uYx966KFss802vOhFLxr3viRJkqSN0ZQqLF/60pdYsGDBI157/vOfzw033MB1113HTjvtxCmnnLLKz/7Jn/wJhx56KDfeeCOLFi1i1qxZ487z5je/mU984hPj3o8kSZK0sZpShWVVDjnkEKZNmwbAvvvuy6233vqYbe69914uv/xyjjvuOAA222wzttlmGwBuuukmDj30UObMmcOBBx7IjTfeuM7HPvjgg3niE584Ad9CkiRJ2jhN+cKysrPOOovDDjvsMa//4Ac/YGRkhFe96lXstddevPrVr+a+++4D4Pjjj+eDH/wgCxcu5NRTT+W1r33tsGNLkiRJG61UVd8ZJlWSxcAWDMrZJsA0YFn39q3Az7rHTwaeANy0it08HpgF3AjcBzwd2Bz4PrAnsHTlQwLfBLYBnrqKfS0DvrvS8ycC2wPf+9W+2SrNAO6agP1MpA090zOqamQyw0iSJGn1NvrCsrIkzwUWVNWCR72+ADgBOLiqfrGKzz0ZuKaqRrvnBwIXAzOBb1fVU8aZ6U1VNe6Z90nGqmruePczkcwkSZKk8Zjyl4QlORQ4EZi/qrICUFW3Az9KsnP30sHA0qr6GfCDJC/r9pUks4eRW5IkSZoKpnxhAU5ncFnWF5Jcm+QjAEl2SPIvK233euCcJNcxuAzsJ93rfwAcl2QRg0vBXrKuB05yBfBp4OAktyZ5wfi/jiRJkrTxmFKXhE2kJMdX1Zl951iZmdZNi5kkSZK0ahYWSZIkSc3ykjBJkiRJzZrWd4DJlmSNQ0hz5swZVhRtgBYuXHjX6pY1njFjRo2Ojg45kTYWazq3JEnSf9voC8vajI2N9R1BDUty8+reGx0d9fzRelvTuSVJkv6bl4RJkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktSsDaawJEnfGSRJkiQNV9OFJclTk4wCVFVZWiRJkqSppdnCkuR3gX8FzkxyAQxKy6+6nzlz5lBVq/2RJEmS1K4mC0uSOcD/BU4AXgA8mGSrflNJkiRJGrYmCwsQ4N+q6mrgqcCBwLuT/EOSzWDNc1qSHJ9kLMnY4sWLh5NYkiRJ0oRrtbAsBXZL8j7gcuD9wP8EHg98GtZ8eVhVnVlVc6tq7sjIyDDySpIkSZoE0/oOsEKSecBvAt8AvsrgcrAdgO2BD1TVL4D5Sf41ya9V1U/7SytJkiRpGJoYYUlyCPB3wAzgJcCFwPZVdRWwBJjdbff7wK8BD/QUVXrY9ddfT5JV/oyOjvYdTw0YHR1d7TkiSZLWTSsjLLOBM6rqvUm2Bl4GfDTJy4BLGawU9g3g2cAxVfWzHrNKACxbtmy1K835D1IB3HzzzZ4jkiSNUyuF5T5gb4Cquhf4225S/XuB3wO+A0wHFlfVzb2llCRJkjRUvV0S1t0Ucmb39GxgnyQnr7TJBcCPgDlVtaiqxiwrkiRJ0tTSS2FJciSDQvKZJKcwGF15AbB/95xuUv2mwF59ZJQkSZLUv6FfEtbNUflz4I+AOxhMsj8G+DLwcuDzSbYD7mZw/5W/GXZGSZIkSW3oYw7LpsCDwD1VdVuSTwGLgecB3wP2Aw4HtgEOr6rv9pBRkiRJUgOGXliq6r+S/BvwziR/WlV3JrkMeBowv6q+Bpwz7FySJEmS2jOUOSxJXpTk5CRnJJkBnAt8GzgxyfZVdReDOS3PTfLkYWSSJEmS1L5JLyxJ5gAfAa4BtgDeD+wKXA38HDgjyc7Avt1Hlk52JkmSJEkbhmGMsOwEXFpVF1XVscCVwCHA4xgsZ3wd8D7gNcAbquqeIWSSJEmStAEYRmH5KrBDkv0BqurDwA3AK4C7q+odDO5sf1hV/ccQ8kiSJEnaQExKYUmyZ5JZSXatqu8DC4EDk+wCUFUfYrBS2End8yVV5aVgkiRJkh5hwgtLksOAi4HXAecneSnwMeDXgZckOajb9GsM5rBIkiRJ0ipN2LLGSQI8AXg98LqquijJfsAngbcCpwALgLcnuQPYH3jhRB1fkiRJ0sZnwgpLVRWwJMkYsFWS6VV1dZKjgfOBN1bV25M8DdgLOLGqbpmo40uSJEna+EzGHJbbgYMZLGFMdyPIY4C3JvmNqrq1qi62rEiSJElamwkrLN0lYSsm1D8e+HCSrbuRlisYLF/80EQdT5IkSdLGb1yXhHU3fNwWGAOW0xWSqjoqyXkM7q9yTZJpwEEMVgaTJEmSpHWy3oUlyRHAycBt3c9YkrOr6mcAVXV0kmOBHYDZwPyqunUCMkuSJEmaItarsCSZDhwFHFdVV3VLF+8LvCXJu6rqXoCqOqvbfvOqun+iQkuSJEmaGsYzh2Ur4Fnd4wuBzwHTgaMBkuyTZO/u/WXjOI4kSZKkKWq9CktVPQC8FzgiyYFVtRy4ErgWmJdkC+AA4Mfd9jVBeSVJkiRNIeMZYbkCuBQ4Jsm8qnqoqs5lMGdlh6o6rapun5CUkiRJkqak9Z50X1VLk5wDFHBSkl2A+4ERYMkE5ZMkSZI0hY1rWeOqujvJR4FvAScAS4FXVtUdExFOkiRJ0tQ2rsICUFXLgMuSXD54WsvHH0uSJEmSJqCwrFBV3sVekiRJ0oQaz6T7SZdkxySb9Z1DkiRJUj+aLSxJRoHvACck2brfNJIkSZL60GxhYXCzye8DLwJemWSrnvNIkiRJGrIJm8My0arqx90KZDcBrwXuTfJd4L+q6rtr+myS44HjAWbOnDnpWSVJkiRNjmZHWJJMA57J4J4uRwJvBK4C1tpAqurMqppbVXNHRkYmN6gkSZKkSdPMCEuSecA+wCLgpqr6fpLzgKcAWzG4IeV1wGiSJ1bVz/tLK0mSJGkYmhhhSXII8HcMSskLgY8m2Rf4AXAqcDXwPxiMtLwEmN5TVEmSJElD1MoIy2zgjKp6b7ci2MuAjwKHAycB91bVZQBJjqqqX/YXVZIkSdKwtFJY7gP2Bqiqe4G/TbIJ8EHg1VV1W/e8gKX9xZQkSZI0TL1dEpbkqUlWTKA/G9gnyckrbXIB8EPgGQBVtbw6Qw0qSZIkqTe9FJYkRzIoJJ9JcgqD0ZUXAPt3z6mquxjMVdmzj4ySJEmS+jf0S8K6OSp/DvwRcAeDSfTHAF8GXg58Psl2wN3AgcDfDDujJEmSpDb0MYdlU+BB4J5ubsqngMXA84DvAfsxmGy/DXD42m4SKUmSJGnjNfTCUlX/leTfgHcm+dOqujPJZcDTgPlV9TXgnGHnkiRJktSeocxhSfKiJCcnOSPJDOBc4NvAiUm27+arXAA8N8mTh5FJkiRJUvsmvbAkmQN8BLgG2AJ4P7Arg5tB/hw4I8nOwL7dR1y2WJIkSRIwnBGWnYBLq+qiqjoWuBI4BHgcg+WMrwPeB7wGeENV3TOETJIkSZI2AMMoLF8FdkiyP0BVfRi4AXgFcHdVvYPBne0Pq6r/GEIeSZIkSRuISSksSfZMMivJrlX1fWAhcGCSXQCq6kMMVgo7qXu+pKq8FEySJEnSI0x4YUlyGHAx8Drg/CQvBT4G/DrwkiQHdZt+jcEcFkmSJElapQlb1jhJgCcArwdeV1UXJdkP+CTwVuAUYAHw9iR3APsDL5yo40uSJEna+ExYYamqApYkGQO2SjK9qq5OcjRwPvDGqnp7kqcBewEnVtUtE3V8SZIkSRufyZjDcjtwMIMljOluBHkM8NYkv1FVt1bVxZYVSZIkSWszYYWluyRsxYT6xwMfTrJ1N9JyBYPlix+aqONJkiRJ2viN65Kw7oaP2wJjwHK6QlJVRyU5j8H9Va5JMg04iMHKYJIkSZK0Tta7sCQ5AjgZuK37GUtydlX9DKCqjk5yLLADMBuYX1W3TkBmSZIkSVPEehWWJNOBo4DjquqqbunifYG3JHlXVd0LUFVnddtvXlX3T1RoSZIkSVPDeOawbAU8q3t8IfA5YDpwNECSfZLs3b2/bBzHkSRJkjRFrVdhqaoHgPcCRyQ5sKqWA1cC1wLzkmwBHAD8uNu+JiivJEmSpClkPCMsVwCXAsckmVdVD1XVuQzmrOxQVadV1e0TklKSJEnSlLTek+6rammSc4ACTkqyC3A/MAIsmaB8kiRJkqawcS1rXFV3J/ko8C3gBGAp8MqqumMiwkmSJEma2sZVWACqahlwWZLLB09r+fhjSZIkSdIEFJYVqmrC72KfJE7YlyRJkqau8Uy6H4atkzycMUn6DCNJkiRpuJotLEnmA18ATk/yQXB5ZEmSJGmqabKwJNkJ+GvgfwLvAvZIcn6Sx3XvO9IiSZIkTQFNFhbg58B3gEVV9cOqOgjYFPgErH2kJcnxScaSjC1evHjy00qSJEmaFK0Wll8A9wJzVrxQVS8Ftk9y6to+XFVnVtXcqpo7MjIyiTElSZIkTaZmCkuSeUnelOT5DHJ9CjglyT4rbfYaGsosSZIkaXI18Y//JIcAfweMAC8GPg18G3gn8KEk85M8BdgfmJtki97CSpIkSRqaCbsPyzjNBs6oqvcm2Ro4CrgImA+cBLwUOBZ4GnBsVf2yt6SSJEmShqaVwnIfsDdAVd0LnNktBPYh4GjgKmALYFpV3dFXSEmSJEnD1dslYUmemmRm9/RsYJ8kJ6+0yT8CtwC7VtUvquqnlhVJkiRpaumlsCQ5ErgA+EySUxiMrrwA2L97TlX9lMEI0F59ZJQkSZLUv6FfEtbNUflz4I+AO4CXAMcAXwZeDnw+yXbA3cCBwN8MO6MkSZKkNvQxh2VT4EHgnqq6LcmngMXA84DvAfsBhwPbAIdX1Xd7yChJkiSpAUMvLFX1X0n+DXhnkj+tqjuTXMZgBbD5VfU14Jxh55IkSZLUnqHMYUnyoiQnJzkjyQzgXAb3WTkxyfZVdReDOS3PTfLkYWSSJEmS1L5JLyxJ5gAfAa5hsDTx+4FdgauBnwNnJNkZ2Lf7yNLJziRJkiRpwzCMEZadgEur6qKqOha4EjgEeByD5YyvA94HvAZ4Q1XdM4RMkiRJkjYAwygsXwV2SLI/QFV9GLgBeAVwd1W9A3gZcFhV/ccQ8kiSJEnaQExKYUmyZ5JZSXatqu8DC4EDk+wCUFUfYrBS2End8yVV5aVgkiRJkh5hwgtLksOAi4HXAecneSnwMeDXgZckOajb9GsM5rBIkiRJ0ipN2LLGSQI8AXg98LqquijJfsAngbcCpwALgLcnuQPYH3jhRB1fkiRJ0sZnwgpLVRWwJMkYsFWS6VV1dZKjgfOBN1bV25M8DdgLOLGqbpmo40uSJEna+EzGHJbbgYMZLGFMdyPIY4C3JvmNqrq1qi62rEiSJElamwkrLN0lYSsm1D8e+HCSrbuRlisYLF/80EQdT5IkSdLGb1yXhHU3fNwWGAOW0xWSqjoqyXkM7q9yTZJpwEEMVgaTJEmSpHWy3oUlyRHAycBt3c9YkrOr6mcAVXV0kmOBHYDZwPyqunUCMkuSJEmaItarsCSZDhwFHFdVV3VLF+8LvCXJu6rqXoCqOqvbfvOqun+iQkuSJEmaGsYzh2Ur4Fnd4wuBzwHTgaMBkuyTZO/u/WXjOI4kSZKkKWq9CktVPQC8FzgiyYFVtRy4ErgWmJdkC+AA4Mfd9jVBeSVJkiRNIeMZYbkCuBQ4Jsm8qnqoqs5lMGdlh6o6rapun5CUkiRJkqak9Z50X1VLk5wDFHBSkl2A+4ERYMkE5ZMkSZI0hY1rWeOqujvJR4FvAScAS4FXVtUdExFOkiRJ0tQ2rsICUFXLgMuSXD54WsvHH0uSJEmSJqCwrFBV3sVekiRJ0oQaz6R7SZIkSZpUG0xhSZK+M0iSJEkarqYLS5LnJDkYBpNjLC2SJEnS1DJhc1gmUldMngR8DviPJE+sqn/qSsuma5svk+R44HiAmTNnTn5gSZIkSZOiyRGWGvgv4B+BK4HfTvKy7r21Tu6vqjOram5VzR0ZGZnktJIkSZImS7MjLFVVwB3AE4Drgd9KMgr8oqrOWJeRFkmSJEkbtmZHWLqHXwZ+VFV/CywD3gFs221jWZEkSZI2cs0UliTzk3wkyZlJ9upevhnYLckRwEuBjwEzk8zvLagkSZKkoWmisHQF5VTgn4HvAB/v5qz8EtgcOA3446r6YwZzWsb6yipJkiRpeFqZw/J0YFFVXQxcnOT7wKuBe4DzgU9W1Ze7bc+pqgd7yilJkiRpiJoYYQG+ASxNMqebcH8BcDaDUZfbqurLSTbp3rOsSJIkSVNEb4Wluynkvkn2qKofAT8BjgSelmSTqjof+BTwhwBVtXylyfiSJEmSpoBeLglLchjwAQargD0lyRhwEoNJ9a8FLgKuBu4DZvSRUZIkSVL/hl5YkkxncBf6v6yq85JsB3yRwf1WjmOwdPHrk7wN+A3g5cPOKEmSJKkNQy8sVfVAkoXAQ93zO5PszWDlr7dV1duSjACzgW93l4tJkiRJmoKGNoclyZNWevpd4G1JZgB0E+lfCOyd5FlVtbiqvmhZkSRJkqa2oYywJHkR8NokdwBXAJ8Engl8PclzququqrotyVLg8cPIJEmSJKl9k15YkuwEfAR4BTAKPAv4OIP5KgV8Icn7ge2APRjce0WSJEmShjLC8iDw+aq6HLg8ydOBVwEfBRYwuDzsGQzmrPx+Vd08hEySJEmSNgDDKCx3A/sk+ZOqen9V/SjJ2cBrgCOr6jyA7t4ry4eQR5IkSdIGYlIm3SfZP8kfJvntqrob+B/AYUlW3ATyFuBm4KAVn7GsSJIkSXq0CS8sSZ4PXMxgvsp7kvwl8CTgVOAPkryx23QpMCOJk+wlSZIkrdKEXhKWJMBc4I1V9fEk/wgcDjwPuBT4c+Dvk+wBPBeYX1W/mMgMkiRJkjYeE1pYqqqS3Ae8MsmFVXVDkl8ArwR+q6remeQgYItu8zsn8viSJEmSNi6TMYflk8AiBpd/Pb6qvg/8E/CKJAdU1c+q6g7LiiRJkqS1GVdh6S4Be7R7gK8zuN/KgiRbVdV1DC4J2248x5MkSZI0tYz3krBNGdxnBYAk06rqwSSfAZYD+wL/kuSfgT8APjDO40mSJEmaQta7sCQ5DDguyULg1qr6RFdWplfVA11pWVFUNgfmdZeHSZIkSdI6Wa/CkmQfBqMlb2cwknJSkllV9daurEyrqgeBXwAfTZKqqglLLU2QVV/VKEmSpFas7wjLZsCXquocgCRfAr7S9ZK3dSMtBwF7V9VplhVJkiRJ62N9J93/Etg+ybYAVfUTYD8Gd7M/qtvmLuDT448oSZIkaapar8JSVQuBW4FLVnrtduAMupXAquqbVXXrRISUJEmSNDX9yoUlyWYAVfVa4M4kVyZ5cvf2DGBukk1Ws+RxL4499li22247dt999wnZ36abbsqee+7Jnnvuyfz589f5czfeeCP77bcfm2++Oaeeeupqtzv99NPZcccdScJdd9318Ouf/exn2WOPPdhzzz2ZO3cuV1555cPvnXjiiey2227MmjWLN7zhDaztKrzVHUOSJElqya9UWJJsUlXLuscnAe8BvgF8KMk/AAuAd1XV8pbmrSxYsIBLLrlk7Ruuoy222IJrr72Wa6+9losuumiV24yOjj7mtW233ZYPfOADvOlNb1rj/g844AC++MUv8oxnPOMRrx988MEsWrSIa6+9lrPOOotXv/rVAHzlK1/hqquu4rrrruOGG27g61//Ol/+8pfX6xiSJElSS9a5sHRlZXn3+F3Ai6rqsqp6PfA24N3AYVX1zcmJuv7mzZvHtttu+4jXbrrpJg499FDmzJnDgQceyI033jjpObbbbjue85znMH369DVut9dee62y8Gy55ZYPr2p13333Pfw4CUuXLmXZsmXcf//9PPDAA2y//fYAXHrppey3337svffevOxlL2PJkiVrPIYeY3bfASRJkqayrMtAyKPKyqnAbsCLu6WLm5ZkMXAzg5XNngWsKFQ7da/fDzwBeCrwnXXc7RxgGfAAcDtwzyq2eTZw/Wo+vwPwEHDHWo7zbOA/WenmnMA2XdbpwHeB+7rXn8Zg/tByYDFwG4NV4H6j22458GQgwE/WcoyJNIPBAgwtWddMs4FpVbXKyxtXOrf61MrfrzkeaV1yPKOqRoYRRpKkDdk6FZaHN07eA8wC5ndLF29aVQ9NWroJlGQU+FxV7Z5kSwb/qP/2SptsXlWzkhwBvGMVu7itql7Q7eupwGeB3wf+HTi4qm5KcgZwQLf9rsC3usefrqq/XinL24ElVbX6iSyD7X4IzK2qx/zDJ8k84C+r6nlJdgTeDzwFmAd8ATgR2Bo4m8ECCTAobVdX1XHrcoyJkGSsquZOxr7XV4uZ1lcr38UcbeaQJGljsM73YUkyE9iZDbCsrMImwD1Vteej36iqC4AL1vThqrotCVX1/e4eNHsBN1XV61Zsk+SHq9r/RKmqy5P8epIZwOHANcBLqmpJkn9lsMz0fwJfqKqjJyuHJEmSNJnWeQ5LVd1CdxnYBl5WqKqfAT9I8jKADKzTXIUkT0qyefd4BoMRlW+t+VMTI8mOK1ZfS7I3sDnwU+AW4KDu9end4/9kUGIO6EZgSPKEJDsNI6skSZI0EX6lVcJWrPy1oZWVJOcBVwM7J7k1yXHAHwDHJVnEYF7LS9Zxd7OAMWB74DLg/1bVOhWWJE9OcivwRuB/dVm26t77lyQ7dI/f0G33NOC6JH/b7eKlwA1JrmVwz5ujuv8mnwFuYjC3ZRGwqKourqrFDFZuOy/Jdd3fwS5rOcZEO3OS9jseLWZaX618F3M8Uis5JEna4P1Kc1gkSZIkaZjW6073kiRJkjQM6zzpfkM1Y8aM8n4jWp2FCxeudZs1LGu8xuHJOXPmrGcqTQULFy68a3XLGvt7S+OxpnNLkjZEG31hGR0dZWxsrO8YatSKm2+uwXrfn8bzTmuSZLX38PH3lsZjTeeWJG2IvCRMWrNFfQeQJEmayiwskiRJkpplYZEkSZLULAuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFk1pVbXGnzWZM2fOen9WkiRJ68bCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZGkxlx//fUkeczP6Oho39HUmNHR0cecJ5K0sZnWdwBJ0iMtW7ZslUtj+49RPdrNN9/8mHPF80TSxsYRFkmSJEnNsrBIkiRJapaFRZIkSVKzNqjCkmSDyitJkiRpfJqedEFNxCUAACAASURBVJ/khcA+wGbAqVX1054jSZIkSRqiZkcskvwmcDrwbeBJwEVJ9k8yfR0+e3ySsSRjixcvnuyomkI8tyRJkoar2cIC7A5cWlXnVtVrgH8ETgTmwJovD6uqM6tqblXNHRkZGU5aTQmeW5IkScPVcmH5OrBFkl0Aquq9wJXAaUm2qarlvaaTJEmSNOlaLiy3Aw8Cz08yA6CqTgVuAE7oM5gkSZKk4WiqsCTZdMXjqroT+CDwAuDoJM/u3roJeOwtoCVJkiRtdJpYJSzJTlX1nap6KMmm3Z+pqm8k+QsGIyoHJCkGq4b9Xr+JJUmSJA1D7yMsSV4EXJvkXICVSksl2aSqvgH8L+AvgIuB51XV9T1GliRJkjQkvRaWJE8A/hj4U2BZkk/Cw6Vl2koT6x+squ92K4b9oK+8kiRJkoar18JSVfcBxwLnAm8CHrdSaXkQIMls4JVJHpckvYWVJEmSNHS9XxJWVT+uqiVVdReDuSpbrCgtSfYAdgTOr6qlVeVke0mSJGkK6b2wrKyqfsqgtDyQ5NsMbhb5lW7FMEmSJElTTFOFBaAbabkO2Bo4oqp+0nMkSZIkST1prrAkeRLwu8AhrgYmSZIkTW1N3IdlZVV1d5IXV9XSvrNIkiRJ6ldzIywAlhVJkiRJ0GhhkSRJkiSwsEiSJElqmIVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZFhZJkiRJzbKwSJIkSWqWhUWSJElSsywskiRJkpplYZEkSZLUrOYLS5LN+84gSZIkqR9NF5YkvwO8OslmfWeRJEmSNHzNFpYkhwLvA66rqmV955EkSZI0fE0WliR7AOcB76iqK5L8WpIZSZ65jp8/PslYkrHFixdPblhNKZ5bkiRJw9VkYQEeB5wPPDnJXOAc4D3A55MsWNuHq+rMqppbVXNHRkYmN6mmFM8tSZKk4WqysFTV14C/B3YEvghcBBwHHAu8M8luPcaTJEmSNCTT+g7waEk2qarlVXVVkuXAFVX1j0lSVVcmuQS4v++ckiRJkiZfE4Ulyc7AtsAYsHzF61V19YoVwqqqkhwF7AX8spegkiRJkoaq98KS5AjgZOC27mcsydlV9bNuVGVZkmnAK4A3AUdX1W09RpYkSZI0JL3OYUkyHTgKOK6qDgY+CzwdeEuSrauqAKrqQeDnwBFV9c3eAkuSJEkaqhYm3W8FPKt7fCHwOWA6cDRAkn2SzKqqC6vqez1llCRJktSDXgtLVT0AvBc4IsmBVbUcuBK4FpiXZAvgAOCeHmNKkiRJ6kkLIyxXAJcCxySZV1UPVdW5wA7ADlV1WlX9pN+IkiRJkvrQ+6T7qlqa5ByggJOS7MJg2eIRYEmv4SRJkiT1qvfCAlBVdyf5KPAt4ARgKfDKqrqj32SSJEmS+tREYQGoqmXAZUkuHzyt5Wv7jCRJkqSNWzOFZYWqeqjvDJIkSZLa0MKke0mSJElaJQuLJEmSpGZZWCRJkiQ1y8IiSZIkqVkWFkmSJEnNsrBIkiRJapaFRZIkSVKzLCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElq1rS+A6xJkj2B+wGq6j97jiNJkiRpyJodYUlyGHAx8Frg00le1XMkSZIkSUPW3AhLkgBPAF4PvK6qLkqyL/DJJJtX1UfWYR/HA8cDzJw5c1Lzamrx3JIkSRqu5kZYamAJMAZslWR6VV0DvBx4S5IF67CPM6tqblXNHRkZmeTEmko8tyRJkoarucKyktuBg4EtAKpqDDgG+OMkz+wzmCRJkqThaK6wdJeEUVUfAh4PfDjJ1t1Iy5XAdUD1mVGSJEnScDQxhyXJzsC2DC4DWw48BFBVRyU5D3gfcE2SacBBwIN9ZZUkSZI0PL0XliRHACcDt3U/Y0nOrqqfAVTV0UmOBXYAZgPzq+rW3gJLkiRJGppeC0uS6cBRwHFVdVWSlwL7Mphc/66quhegqs7qtt+8qu7vL7EkSZKkYWphDstWwLO6xxcCnwOmA0cDJNknyd7d+8uGH0+SJElSX3otLFX1APBe4IgkB1bVcuBK4FpgXpItgAOAH3fbO9lekiRJmkJaGGG5ArgUOCbJvKp6qKrOZTBnZYeqOq2qbu83oiRJkqQ+9D7pvqqWJjmHwVLFJyXZBbgfGAGW9BpOkiRJUq96LywAVXV3ko8C3wJOAJYCr6yqO/pNJkmSJKlPTRQWgKpaBlyW5PLB01redyZJkiRJ/WqmsKxQVQ/1nUGSJElSG1qYdC9JkiRJq2RhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWRYWSZIkSc2ysEiSJElqloVFkiRJUrMsLJIkSZKaZWGRJEmS1CwLiyRJkqRmWVgkSZIkNcvCIkmSJKlZzReWJOk7gyRJkqR+NF9YgC37DiBJkiSpH00XliSHAn+f5AmOtEiSJElTT7OFJclhwF8AH6qq+6qqfoXPHp9kLMnY4sWLJy+kphzPLUmSpOFqrrBkYBT4Z+ADVfWFJDsk2b/72Xxt+6iqM6tqblXNHRkZmezImkI8tyRJkoarucJSAz8E3gO8NclzgHOAPwTOAv4sydY9RpQkSZI0JM0VliSbAFTVm4FLgK8CF1bVCcDvA0cCv9lfQkmSJEnDMq3vADC4DGzFHJWqWp5kk6paXlVvSfK5qrqie++6JJcDW/UaWJIkSdJQtDLCsumjX1hppOWKlV47BjgE+I/hRZMkSZLUl95HWLrVwI5LshC4tao+sWKUZaVtNgd+G3grcGRVfb+nuJIkSZKGqNcRliT7AB8ALgR+CLw5ycnw35eGdY/vBxYCz6uqb/YUV5IkSdKQ9T3Cshnwpao6ByDJl4CvdFNa3taVlucCz66qD/aYU5IkSVIP+p7D8ktg+yTbAlTVT4D9gMOSHNVtsxj4p57ySZIkSepRr4WlqhYCtzJYvnjFa7cDZwDbdc+/WVU/6iehJEmSpD71VliSbAZQVa8F7kxyZZInd2/PAOYm2SRJ+sooSZIkqV+9zGHp7rOyrHt8EoO72h8BfCjJMmA2g9XAlveRT5IkSVIbhl5YVtwUsnv8LuCAqjoFuCzJLODxwE+r6ofDziZJkiSpLUMtLI8qK6cCuwEHrXi/qv5zmHkkSZIktW2oc1hWKivvAXYFXlxVDyZ5zJ3uJUmSJGnok+6TzAR2BuavKCtV9dCwc0iSJElq39ALS1XdwkojK5YVSZIkSavTy7LGVVXdn5YVSZIkSavV953uJUmSJGm1LCySJEmSmmVhkSRJktQsC4skSZKkZllYJEmSJDXLwiJJkiSpWdP6DjDZFi5cSJLVvt+tsCxJE25Nv3skSdK6cYRFkiRJUrMsLJIkSZKa1XxhiddUSJIkSVNW04UlyTzgLUnmJ3n6ZBzj05/+NLvtthubbLIJY2Njq9xm6dKl7LPPPsyePZvddtuNv/qrv3r4veOOO47Zs2ezxx57cOSRR7JkyRIALr/8cvbee2+mTZvGZz7zmXXKcuyxx7Lddtux++67j/+LSZIkSRuBZgtLkt8BLgAeBE4A/izJy9fxs8cnGUuy6gaykt13350LLriAefPmrXabzTffnH//939n0aJFXHvttVxyySVcc801AJx22mksWrSI6667jpkzZ3L66acDMHPmTM4++2xe8YpXrEtkABYsWMAll1yyzttr+FY+txYvXtx3HEmSpI1es4UFeCbw9qo6FXgt8A3gd9altFTVmVU1t6rmrm3bWbNmsfPOO69xmyRsueWWADzwwAM88MADD6/+s9VWW604Jr/85S8ffn10dJQ99tiDTTZ57F/xu9/9bp7znOewxx57PGK0Zt68eWy77bZri6werXxujYyM9B1HG7bZfQeQJGlDkFaX9U2yAHgDcHBV3Z1kBnAYg/+Rf1dV3bmO+ykGozSLgCcCvwb8cBWb7gz8CPjFGna3K7A5cCdwP3BX9/oosDXwS+B7wPKVPjMK3Avc3T3fCngScHP3fEfgdmBJ93wz4FnAN9f65R5rxkqZWrGhZ3pGVa2ymSRZzH//d+xLK3+/5nikteWYDUyrqlXO0XvUudXXd/K4G+6xV/t7S5I2RM0WFoAk7+4evrOq7k3yTOBjwN9U1ed/hf18lUHR2BLYFrile+stK/aT5EvAm6pqjZeRJdkGuBAYqardV3p9U+CDwNer6u9Wev1s4HNV9Znu+anAkcA93SZbAqdU1ce690e77X/liSxJxtZlVGmYzDS5Wvku5pi8HH19J487NY4tSRuCli8JA/h09+dfJNm2qn4AfJ3BqMQ6q6rfrKo9gVcDF1XVnt3POpeelfZ1D3AZgxGVlV9/CPgH4KVr2UUYFJQVGXZcUVYkSZIkPVLrheXrwKeAAr6c5P8ArwIuHWaIJCPdyApJtgCeDyzNwI7d6wHmAzeuZXefB45NsmX3uacm2W7y0kuSJEkbrml9B0gyF7i7qm569Hs1uF5tDFix4lcBB1bVdyfw+IczuJRrBPjnJNdW1QuS7AD8bVX9LvAU4OPdZV+bAOczmHeS7vWtuseLgD/q9vscBpeOPQl4cZL/XVW7VdWlSWYBV3cT9JcArwTuTHIe8FxgRpJbgb/6FUdfzhzXX8bkMNPkauW7mOORJjJHX9/J406NY0tS83qdw5Lk+QxGHC5kMJ/ke72FkSRJktSc3i4J6y6t2htYAPwA+MsVl1c9aruDk5wy5HiSJEmSGtD3CMszgR9WVSX5MPB44K+r6jsrbbMV8KSq6nv5WEmSJElD1tSyxkn+H/A4BjeK/D3gF1V14Tj3ucYvOGfOnPHsXhu5hQsX3rW6+xnMmDGjRkdHh5xIG5KFCxeu8f013IfF31tab2v6vQX+7tL4rO38kiZDb4UlyabdUsAkeVJV3d09PgV4IYNlg/8M+EFVfWMcx1njF2ypsKk9SRau7v4Ic+fOrbGxNd62R1Nct7DG6jxYVdNX8zl/b2m9ren3Fvi7S+OztvNLmgy9zGFJsslKZeX/AL/TrcAF8F3g6cBfA38BPNBHRkmaZIv6DiBJ0oZg6IWlKyvLu8fvAg4EPltVD3X3OtkeeDODsnJ8Vd2QZLNH7WON/7dlkuOTrFgKWZowK59bixcv7juONiL+3pIkadWGWlgeVVZOBZ4NPK+qHuzeu4fBPVFmAN8CbkmyNfDhJKclOR0evj/LalXVmVU11yFLTbSVz62RES/h1cTx95YkSas21MKyUll5D7Ar8OKurGy64r2qWgJ8HPgc8H7gBuB7DO7VsleSjw8zsyRJkqT+DP1O90lmAjsD81cqKw8lOQj4LQbl5N8Z3E1+a+DKqjq9++wrgL9aeaRGkiRJ0sZr6HNYquoWHjmy8lCSw4APAJsBL+nevwM4HTjz/7N352FzlfX9x98fkrC2IJggImq0yiayJewCKgqiFBRBipVCQUGhalEBkS6u0FoEN9QfaEULuCIWaYtYBQU3TBQRUSoKKFQgbCLVGJJ8f3+c8+BjTEJIZuac5Hm/rmuuZ5Yzc39n5n7uOd9zL2fc0/cBHttut0xmzJhBVS3xIknDsrxtj+2WJEm/N/IeFvj9HJQ2WdkCOAU4tqq+nuT1wFOSPBn4bVXd106y/yvgOODQqprbRdySJEmSRquThGURNwHHVdX3k0wDXgn8EHgt8MQkJwL3AzvQJCvXdxeqJEmSpFHq5DwsAEkel+RJVTW3qsbOR7Ad8NaqeiHNeVhuBbauqtuBE01WJEmSpImlkx6WJAfRnGslSS4FvldVF1XVZWPbVNWdSVYDNmzv+m0HoUqSJEnqUBcnjlwPeD3wKuBFwO3A3klesch2BwO7AJfBw597RZIkSdKqp4shYZOA+cB9VXUb8CmaZYy3S7IfQJLDgbcCL6uqGzuIUZKkVdIPfvADkiz2Mn369K7DUw9Mnz59iXVE6kIXyxrfA3wZeHuSDavqbuBy4CfAjHazC4HnVdUPRx2fJEmrsnnz5i1xyexbbrml6/DUA7fccovLqqtXRpKwJNkvyalJzkoyFbgAuAE4Mcljquou4HPAc5M8rqoeqCpbTUmSJGmCG3rCkmQG8CHgW8BawHuALYFvAr8GzkqyGbBz+5T/G3ZMkiRJklYOo+hh2RS4rKourqojgauAvYE1gXOBa4F305x/5TVVdd8IYpIkSZK0EhhFwvJtYOMkuwJU1QeB64CXAvdW1VuBg4F9q+q7I4hHkiRJ0kpiKAlLkm2TbJFky6r6GTAb2D3J5gBV9QGalcJObm8/UFVzhxGLJEmSpJXXwBOWJPsCXwCOAz6d5MXAR4AnAwck2bPd9GqaOSySJEmStFgDO9N9msW51wFeDRxXVRcn2QU4D3gTcBpwBPDmJHcAuwIvGFT5kiRJklY9A0tY2jPRP5BkFrBukilV9c0khwKfBl5XVW9OsgmwHXBiVf18UOVLkiRJWvUMYw7L7cBeNEsYU1VXA4cBb0ryZ1V1a1V9wWRFkiRJ0sMZWMLSDgkbm1C/NvDBJOu1PS1X0ixfvGBQ5UmSJEla9a3QkLD2hI8bALOAhbQJSVUdkuQTNOdX+VaSycCeNCuDSZIkSdIyWe6EJcmBwKnAbe1lVpJzq+p+gKo6NMmRwMbANsD+VXXrAGKWJEmSNEEsV8KSZApwCHBUVX29Xbp4Z+CkJO+sql8BVNW/ttuvUVW/G1TQkiRJkiaGFZnDsi7w1Pb6RcAlwBTgUIAkOybZvn183gqUI0mSJGmCWq6EpaoeBM4ADkyye1UtBK4CrgH2SLIWsBvwv+32NaB4JUmSJE0gK9LDciVwGXBYkj2qakFVXUAzZ2Xjqjqzqm4fSJSSJEmSJqTlnnRfVXOTnA8UcHKSzYHfAdOABwYUnyRJkqQJbIWWNa6qe5OcA1wPHAPMBV5WVXcMIjhJkiRJE9sKJSwAVTUPuDzJ15qbtXDFw5IkSZKkASQsY6rKs9hLkiRJGqgVmXQvSZIkSUNlwiJJkiSpt0xYJEmSJPWWCYskSZKk3jJhkSRJktRbK03CkiRdxyBJkiRptHqdsCSZmmQ9aE7w0nU8kiRJkkartwlLkhcClwPnJDkvybpdxyRJkiRptHqZsCR5PHAS8HLgZcDqwPuSbLmMzz86yawks+bMmTPESDXRWLc0LNYtSZIWr5cJC/Br4H7gt1U1r6peAtwDnJxkbVj6nJaqOruqZlbVzGnTpo0mYk0I1i0Ni3VLkqTF62XCUlX3AVcDM8bNYTkeWBv4YHvbOS2SJEnSKq43CUuSXZP8TZJ9kqwPXAa8CHhmexvgCGC1JGt2FackSZKk0ZncdQAASfYD/olmkv32wIyqOrWdy/LXwEZJZgObAVvSk7glSZIkDVfnO/5JNgPeChxRVbOS7AO8Icn7quqCJHcDM9pt1gaOqqoHOgxZkiRJ0oh0nrAAPwfeC1wHUFVfTPJqmp6Wr1bVF4EvJvkTYEpV3dtdqJIkSZJGqbOEJcnjgNWr6ibg3Pa+Narqd8ACYI32vpnAbVX1y65ilSRJktSNTibdJzkI+BzwqSRvS3IgQJusANwK3J5kf+A0wBXBJEmSpAlo5D0s7TLFrwdeBdwBHAA8N8n6VfWRdrN7gA+314+qqttHHackSZKk7nUxJGwSMB+4r6puS/IpYA7wrCRzqupiYD3g6cBWVfXTDmKUJEmS1AMjHxJWVfcAXwbenmTDqrqbZjnjn9BMtAf4O2BbkxVJkiRpYhtJwpJkvySnJjkryVTgAuAG4MQkj6mqu2jmtDwnySZVdX9V3TCK2CRJkiT119ATliQzgA8B3wLWAt5Dc/LHbwK/Bs5qz8Wyc/sUz7EiSZIkCRhND8umwGVVdXFVHQlcBewNrEmznPG1wLuBVwKvqar7RhCTJEmSpJXAKBKWbwMbJ9kVoKo+SHOSyJcC91bVW4GDgX2r6rsjiEeSJEnSSmIoCUuSbZNskWTLqvoZMBvYPcnmAFX1AZqVwk5ubz9QVXOHEYskSZKkldfAE5Yk+wJfAI4DPp3kxcBHgCcDByTZs930apo5LJIkSZK0WAM7D0uSAOsArwaOq6qLk+wCnAe8ieaM9UcAb05yB7Ar8IJBlS9JkiRp1TOwhKWqCnggySxg3SRTquqbSQ4FPg28rqrenGQTYDvgxKr6+aDKlyRJkrTqGcYcltuBvWiWMKaqrgYOA96U5M+q6taq+oLJiiRJkqSHM7CEpR0SNjahfm3gg0nWa3tarqRZvnjBoMqTJEmStOpboSFh7QkfNwBmAQtpE5KqOiTJJ2jOr/KtJJOBPWlWBpMkSZKkZbLcCUuSA4FTgdvay6wk51bV/QBVdWiSI4GNgW2A/avq1gHELEmSJGmCWK6EJckU4BDgqKr6ert08c7ASUneWVW/Aqiqf223X6OqfjeooCVJkiRNDCsyh2Vd4Knt9YuAS4ApwKEASXZMsn37+LwVKEeSJEnSBLVcCUtVPQicARyYZPeqWghcBVwD7JFkLWA34H/b7WtA8UqSJEmaQFakh+VK4DLgsCR7VNWCqrqAZs7KxlV1ZlXdPpAoJUmSJE1Iyz3pvqrmJjkfKODkJJsDvwOmAQ8MKD5JkiRJE9gKLWtcVfcmOQe4HjgGmAu8rKruGERwkiRJkia2FUpYAKpqHnB5kq81N2vhioclSZIkSQNIWMZUlWexlyRJkjRQKzLpXpIkSZKGyoRFkiRJUm+ZsEiSJEnqLRMWSZIkSb1lwiJJkiSpt0xYJEmSJPVWrxOWJNsm2a7rOCRJkiR1o7cJS5LnAR8FHuw6FkmSJEnd6GXCkmQv4Bzg6Kq6Lsnqizyeh3n+0UlmJZk1Z86cYYaqCca6pWGxbkmStHi9S1iSrAnsAFwP/DzJesAHk5yZ5P0AVVVLe42qOruqZlbVzGnTpg0/aE0Y1i0Ni3VLkqTF613CUlVzgX8DLgHeA1wH3AhcBGyX5GMdhidJkiRphCZ3HcCYJHsAOwHfo0lSPgJsAHy9qt7XbvNS4B+TrFZVCzsLVpIkSdJI9KKHJcneNBPspwL7A+cBm1XVW4Czx226D/BYYPU/ehFJkiRJq5y+9LBsA5xVVWe0c1ZeAnw8yVFVdXU7yf6vgOOAQ9thY5IkSZJWcX1JWP4P2B6gqn4FnJNkIfCWJK8AimYi/qFVdX13YUqSJEkapc6GhCV5XJIntDfPBXZMcuq4TT4P3AQ8vqpuA040WZEkSZImlk4SliQHAZ8DPpvkNJrelX2AXdvbVNXdNHNVtm+f9tsuYpUkSZLUnZEPCWvnqLweeBVwB3AAcBjwVeAvgC8m2RC4F9gd+Gd4+HOvSJIkSVr1dDGHZRIwH7ivqm5L8ilgDvAcmvOt7AK8CHgU8KKq+kkHMUqSJEnqgZEnLFV1T5IvA29P8rdVdWeSy4FNgP2r6mrg/FHHJUmSJKl/RjKHJcl+SU5NclaSqcAFwA3AiUkeU1V30cxpeWaSjUYRkyRJkqT+G3rCkmQG8CHgW8BawHuALYFvAr8GzkqyGbBz+xTPsSJJkiQJGE0Py6bAZVV1cVUdCVwF7A2sSbOc8bXAu4FXAq+pqvtGEJMkSZKklcAoEpZvAxsn2RWgqj4IXAe8FLi3qt4KHAzsW1XfHUE8kiRJklYSQ0lYkmybZIskW1bVz4DZwO5JNgeoqg/QrBR2cnv7gapyKJgkSZKkPzDwhCXJvsAXgOOATyd5MfAR4MnAAUn2bDe9mmYOiyRJkiQt1sCWNU4SYB3g1cBxVXVxkl2A84A3AacBRwBvTnIHsCvwgkGVL0mSJGnVM7CEpT0T/QNJZgHrJplSVd9McijwaeB1VfXmJJsA2wEnVtXPB1W+JEmSpFXPMOaw3A7sRbOEMe2JIA8D3pTkz6rq1qr6gsmKJEmSpIczsISlHRI2NqF+beCDSdZre1qupFm+eMGgypMkSZK06luhIWHtCR83AGYBC2kTkqo6JMknaM6v8q0kk4E9aVYGkyRJkqRlstwJS5IDgVOB29rLrCTnVtX9AFV1aJIjgY2BbYD9q+rWAcQsSZIkaYJYroQlyRTgEOCoqvp6u3TxzsBJSd5ZVb8CqKp/bbdfo6p+N6igJUmSJE0MKzKHZV3gqe31i4BLgCnAoQBJdkyyffv4vBUoR5IkSdIEtVwJS1U9CJwBHJhk96paCFwFXAPskWQtYDfgf9vta0DxSpIkSZpAVqSH5UrgMuCwJHtU1YKquoBmzsrGVXVmVd0+kCglSZIkTUjLPem+quYmOR8o4OQkmwO/A6YBDwwoPkmSJEkT2Aota1xV9yY5B7geOAaYC7ysqu4YRHCSJEmSJrYVSlgAqmoecHmSrzU3a+GKhyVJkiRJA0hYxlSVZ7GXJEmSNFArMulekiRJkobKhEWSJElSb5mwSJIkSeotExZJkiRJvWXCIkmSJKm3TFgkSZIk9VavE5YkmybZKcnkJKu196XruCRJkiSNxsDOwzJoSQ4E3gH8EvgFMCvJuVX16ySpquo2QkmSJEnD1sseliSrA4cCR1XVs4FLgCcCJyb504dLVpIcnWRWkllz5swZQcSaKKxbGhbrliRJi9fLhKW1LvBn7fXP0SQtawIvfbhhYVV1dlXNrKqZ06ZNG3KYmkisWxoW65YkSYvXy4SlquYBZwIHJ9mtqhYAVwHfB3ZzOJgkSZI0MfQmYUmybZJdxt31HeBLwOFJnlFV86vqPODxSbbuJkpJkiRJo9SLSfdJng98HvhoknWq6r+r6u4k/wUUcEqSzwALgGnA7R2GK0mSJGlEOk9Y2gn2OwCnAfcA+yShTVpuTPJvwI+BVwC/Aw6rqju7i1iSJEnSqHSesFTVvCTvB+4DHgv8NbB3ktWq6rKq+hXw30m+Bixo57NIkiRJmgA6S1iS7ABMAn5bVd9v7741ybk0Sctzk9wGbA1cP24bSZIkSRNEJwlLkn2B9wJfBR6T5KaqO9vltQAAIABJREFUeg1AVf0iyUeBA4CzgBnAzl3EKUmSJKlbI18lLMkU4GjgH6rq5cCRwDPaJAVokhaayfWbATtV1Q9HHackSZKk7o08YamqB4HZNCt+UVVzgB2Bpyc5A6A9MeTawAuq6vpRxyhJkiSpH0aWsCRZf9zNn9AsVTwVoKrm0wwBm55ks2qcUFXfHVV8kiRJkvpnJHNYkuwHHJvkDuBK4DzgScB3kuxQVXdV1W1J5gFrjiImSZIkSf039IQlyabAh4CXAtOBpwIfA46iOSnkl5K8B9iQZkWw+4YdkzSmGX24fGbPnr3U51fVcr+2JC3NirRdkrSyGUUPy3zgi1X1NeBrSR5Ps2zxOcARNMPDnghsA7ykqm4ZQUySJEmSVgKjSFjuBXZM8tqqek+7bPG5wCuBg6rqEwDtiSIXjiAeSZIkSSuJoUy6T7JrksOTPKuq7gX+Ctg3yeEAVfVz4BZgz7HnmKxIkiRJWtTAE5YkzwW+QDNf5V1J/gFYHzgd+Mskr2s3nQtMTbL2oGNY1JFHHsmGG27IVlttNZDXmzRpEttuuy3bbrst+++//zI/78c//jG77LILa6yxBqeffvoSt7vpppvYaaedeMpTnsIhhxzCvHnzADj33HOZNm3aQ2V/+MMffug5J510EltttRVbbbUVn/rUpx66/ytf+Qrbb789W221FYcffjjz588H4N577+VFL3oRW2+9NTvuuCPXXXfdI/0YJEmSpKEbaMLSnj9lJvC6qnoLTc9KAc+hmcvyeuCwdkjYW4C3VtVvBhnD4hxxxBFceumlA3u9tdZai2uuuYZrrrmGiy++eLHbTJ8+/Y/u22CDDXjve9/LG97whqW+/kknncTxxx/PjTfeyPrrr89HPvKRhx475JBDHir75S9/OQD/8R//wXe/+12uueYavv3tb3P66adz//33s3DhQg4//HA++clPct111/HEJz6Rj33sYwCceuqpbLvttlx77bV8/OMf57Wvfe1yfhqSJEnS8Aw0YalmWaT/A16WZN2qug44n6Y35RlV9QOaYWAnATtW1bWDLH9J9thjDzbYYIM/uO+nP/0pz3ve85gxYwa77747P/7xj4cex4YbbsgOO+zAlClTlrhNVfGVr3yFgw46CIDDDz+cz3/+80t93euvv5499tiDyZMns84667D11ltz6aWXcvfdd7P66quz6aabAvDc5z6XCy+88KHnPPvZzwZg88035+abb+aOO+4YxNuUJEmSBmYYc1jOA75PM/xr7ar6GfB54KVJdquq+6vqjqq6cwhlL7Ojjz6a973vfcyePZvTTz+dY489dpmfO3fuXGbOnMnOO+/8sMnEI3X33XfzqEc9ismTm/UQNtlkE2677baHHr/wwgvZeuutOeigg/jFL34BwDbbbMOll17Kb37zG+666y4uv/xyfvGLXzB16lTmz5/PrFmzAPjsZz/7B8/53Oc+B8DVV1/NLbfcwq233jrQ97KK2KbrACTpEbLdkrRKyYqcKyJJapEXSLIacDCwE3AjcF5V3Z/k3cBXq+qiFQl4OWKcQzPBf3Wac8D8kCZR25am5+ehTdvHHgU8bjEvNY9mCWaAKcB6wP3AZsD/AL8DngD8SbvNmuNe/x7g9nGvtTGwAFhcl8ZkYHNgbFLJFGDTNrZJwEKaYXZTgQ3asgE2ojmXzW9pht/9H3AnsA6wSfuef9W+v+vb208A1m6fsyZwc3t9kKYCdw34NVfUssa0DTC5qhZ7woMkRfNZf3+AsT1Sffl8jeMPLUscT6yqaYt7YFy7tayvNQyWu3KWvdR2C/6ofg1KX/73lqTP8fU5Nvjj+JbYdknDsqIJy+Sqmr/o7SSTgAOBnWkSl/8AXgfs1Pa4jFyS6cAlVbVVknWBG6rqsSvwerOqamY7H+eSqvrsIo/fXFXTl/DcNwMPVNUfzbxv5wHNATZqP8tdgDdX1T6LbDcJuKeq1ltMTBfQJIr/uchz9gZeXlUvWUyZNwFbV9X9y/gRLJOxmAb5miuqjzEtr768F+MYXhxdvSfLnRhlD0rf30Of4+tzbND/+DQxLPeQsCT7Ap9McnKSwwDaHewpVbUA+Czw9zRntf81sEdXycqi2p3ym5IcDM0Oe5Jl6kJPsn6SNdrrU4HdaHosBhVbAZcDB7V3HQ78e1ve+ARrf+BH7f2Tkjy6vb41sDVwWXt7w/bvGjRzhz7U3n5UktXb13o58LVBJyuSJEnSilquhCXJjsB7gYtohhGdkORUgKp6sO1pqar6TVWdA5xVVT8aVNDLEe8ngG8CmyW5NclRwF8CRyX5Ps1wqwOW8eW2AGYBW9IkFv9UVcuUsCTZKMmtNL1Nf9fGsm772H8m2bjd9CTgdUluBB4NjC0T9pokP2xjfg1wRHv/FOBK4GnA2cDLxvV8nZDkR8C1wBeq6ivj3sd1SW4A9gVcJkySJEm9s7xnul8duKKqzgdIcgXwjXZKyyltT8uewPZVdeai81xGraoOXcJDz1uO1/oG8PQkR1fV2UvZbvpi7rudZj7J4rZ//rjrPwN2XMw2JwMnL+b+ucCWi4upqk4ATljMc75JMzdm2Jb4GXWojzEtr768F+P4Q4OMo6v3ZLkTo+xB6ft76HN8fY4N+h+fJoDlmsOSZAbwj8ARVXVPe99GwH8C/1xVn0ryNOBXVeXSU5IkSZKWy3INCauq2cCtwKXj7rsdOItmpSqq6ocmK5IkSZJWxCMeEpZk9aqaV1XHJrkkyVXAQW3CMpVmaNJqNPPHOx0KBg8tPbtEM2bMGFUoWgnNnj37riUt3zh16tSaPn36iCPSymT27NlLffxhlsxeItstLc3S2i2w7dLSPVy7BUtuu6xbWhFLa7seUcKSZLWqmtdePxl4F83yxR9IMo9m/feDqmrhCsY8MmMnVZQWJ8kSz1Uwffp064+WqlkxfInmL+3BpbHeaWmW1m6BbZeW7mHaLVhK22Xd0opYWtu1zAlLm6wsbK+/E9itqk4DLk+yBc0JCO+uqptXMF5Jmgi6POGoJC0v2y6N3DIlLIskK6fTLJ+759jjXS5ZLEmSJGnVtUyT7sclK++iOf/In487o70kSZIkDcUyrxKW5AnAZsD+Y8lKe0Z7SZIkSRqKZU5YqurnjOtZMVmRJEmSNGyP6DwsY8sUm6xIkiRJGoXlOnHkymTGjBlU1RIvkjQsy9v22G5J6srS2h7bH3VllU9YJEmSJK28VqqEJclKFa8kSZKkFfOIznQ/akleAOwIrA6cXlV3dxySJEmSpBHqbY9Fkp2A9wM3AOsDFyfZNcmUZXju0UlmJZk1Z86cYYeqCcS6pWGxbmmYrF+SVma9TViArYDLquqCqnolcCFwIjADlj48rKrOrqqZVTVz2rRpo4lWE4J1S8Ni3dIwWb80Cj/4wQ9IstjL9OnTuw5PHZs+ffoS60eSpT63z0PCvgPsmWTzqvpxVZ3RJilnJtm3qu7rOkBJkiQ15s2bt8SVxB5uh1SrvltuuWWpK80trY70uYfldmA+8NwkUwGq6nTgOuCYLgOTJEmSNBq9SliSTBq7XlV3Au8D9gEOTfL09qGfAi4ELkmSJE0AvRgSlmTTqvqfqlqQZFL7N1X1vSR/T9OjsluSolk17IXdRixJkiRpFDrvYUmyH3BNkgsAxiUtlWS1qvoe8HfA3wNfAJ5TVT/oMGRJkiRJI9JpwpJkHeBvgL8F5iU5Dx5KWiZX1cJ20/lV9ZN2xbCbuopXkiRJ0mh1mrBU1f8BRwIXAG8A1hyXtMwHSLIN8LIka8YlJiRJkqQJpfMhYVX1v1X1QFXdRTNXZa2xpCXJ1sBTgE9X1dxa2lpokiRJklY5nScs41XV3TRJy4NJbqA5WeQ32hXDJEmSJE0wvUpYANqelmuB9YADq+qXHYckSZIkqSO9S1iSrA88H9jb1cAkSZKkia0X52EZr6ruTfLnVTW361gkSZIkdat3PSwAJiuSJEmSoKcJiyRJkiSBCYskSZKkHjNhkSRJktRbJiySJEmSesuERZIkSVJvmbBIkiRJ6i0TFkmSJEm9ZcIiSZIkqbdMWCRJkiT1lgmLJEmSpN4yYZEkSZLUWyYskiRJknrLhEWSJElSb5mwSJIkSeotExZJkiRJvWXCIkmSJKm3TFgkSZIk9dbkrgNYmiTPAeYDV1bVgq7jkSRJkjRave1hSTIFOA14B7Bjkl4nV5IkSZIGr7cJC03Pyrfav6cAzwBIkod7YpKjk8xKMmvOnDnDjVITinVLw2Ld0jBZvyStzHqbsFRVAf8JvBm4EDg+yWuAv00y6WGee3ZVzayqmdOmTRt+sJowrFsaFuuWhsn6JWll1tuEZZxXV9VHgduAM4G1nc8iSZIkTQy9TFjGDfv6EnBtkl2AvYCPAM9OsmtnwUmSJEkamV4kLEk2S7JLkilJJlVVJUlVzQd2AL4OvKGqjgY+B9zaacCSJEmSRqLzlbeSHAicSjPk6zZgVpJzq+r+dpNDgM2qajZAVZ3VTaSSJEmSRq3THpZ26eJDgKOqai/g34HHAycleRRAVT0wlqwk6UWPkCRJkqTR6EMCsC7w1Pb6RcAlwBTgLwCSzEyyLUBVLewkQkmSJEmd6DRhqaoHgTOAA5Ps3iYkVwHXAHskWQvYHbi9wzAlSZIkdaQPPSxXApcBhyXZo6oWVNUFwMbAxlV1ZlWZsEiSJEkTUOeT7qtqbpLzgQJOTrI58DtgGvBAp8FJkiRJ6lTnCQtAVd2b5BzgeuAYYC7wsqq6o9vIJEmSJHWpFwkLQFXNAy5P8rXmphPsJUmSpImuNwnLmKpa0HUMkiRJkvqhD5PuJUmSJGmxTFgkSZIk9ZYJiyRJkqTeMmGRJEmS1FsmLJIkSZJ6y4RFkiRJUm+ZsEiSJEnqLRMWSZIkSb1lwiJJkiSpt0xYJEmSJPWWCYskSZKk3jJhkSRJktRbJiySJEmSesuERZIkSVJvmbBIkiRJ6i0TFkmSJEm9ZcIiSZIkqbdMWCRJkiT1lgmLJEmSpN6a3HUAS5NkJ2A6cEdVXdFtNJIkSZJGrbc9LEn2Bc4Dng5ckOSwR/Dco5PMSjJrzpw5Q4tRE491S8Ni3dIwWb8krcx6mbAk2RT4Z+Doqvo74DDgLUk2XpbnV9XZVTWzqmZOmzZtmKFqgrFuaVisWxom65eklVkvExbgfuCNVXV5kslV9WXgeiAdxyVJkiRphHqZsFTV7cA32uvzxz20IUCSLZKs3UVskiRJkkanFwlLkix6varua2+PLQzwJ8D8JC8BPgasOeo4JUmSJI1WX1YJmwTMB6iqSrJaVS1sH1vQ/v0e8EZgE+Coqrpn9GFKkiRJGqXOE5Z2NbCjkswGbq2qf6uqhWNJS1VVu+k6wPOBnavqhs4CliRJkjQynQ4JS7Ij8F7gIuBm4IQkpwKMJS3jNv8AsJ3JiiRJkjRxdN3DsjpwRVWdD5DkCuAbSaqqTmmTlmcCT6uqszqMU5IkSVIHup50/1vgMUk2AKiqXwK7APsmOaTdZg5wcUfxSZIkSepQpwlLVc0GbgUuHXff7cBZtEsYV9UPq+oX3UQoSZIkqUudJSxJVgeoqmOBO5NclWSj9uGpwMwkq41f8liSJEnSxNLJHJZ2BbB57fWTgXcBBwIfSDIP2AY4aNzSxpIkSZImoJEnLOPPsZLkncBuVXUacHmSLYC1gbur6uZRxyZJkiSpX0aasCySrJwOPA3Yc+zxqvrRKOORJEmS1G8jncMyLll5F7Al8OdVNT/JpFHGIUmSJGnlMPJJ90meAGwG7D+WrFTVglHHIUmSJKn/Rp6wVNXPGdezYrIiSZIkaUk6Wda4qqr9a7IiSZIkaYm6PtO9JEmSJC2RCYskSZKk3jJhkSRJktRbJiySJEmSesuERZIkSVJvmbBIkiRJ6i0TFkmSJEm9ZcIiSZIkqbdMWCRJkiT1lgmLJEmSpN4yYZEkSZLUWyYskiRJknrLhEWSJElSb/U+YUmSrmOQJEmS1I3eJyyACYskSZI0QU3uOoClSfIs4IVJrgEuqqr7uo5JkiRJ0uj0toclyd7AOcAtwPHAXo/guUcnmZVk1pw5c4YVoiYg65aGxbqlYbJ+SVqZ9S5hSWMt4KXASVV1BnAmsH2SZyWZ/nCvUVVnV9XMqpo5bdq04QasCcW6pWGxbmmYrF+SVma9S1iq8Vvgp8ArkjwDeDcwFXgjcGySbbqMUZIkSdJo9C5hGbcq2CeAa4BXAWdX1THt9U2Ap3UUniRJkqQR6kXCsrili6vqxqp6I3AhsE6StavqZ8BNwFOX9DxJkiRJq46+rBI2CZgPzZCwJJOqakH72PeAZwBvS3IzcDCw39i2HcQqSZIkaUQ672FJsi/wySQnJzkMoKoWJBmL7efAV4G5wAzghVX1P91EK0mSJGmUOu1hSbIj8F7gzcBC4OQkW1TVm6pqYZIpVfUg8O/AvydZvarmdRiyJEmSpBHqekjY6sAVVXU+QJIrgG8kqao6paoeTPJMYLuqOhN4sLtQJUmSJI1a10PCfgs8JskGAFX1S2AXYN8kh7TbzAE+0z7unBVJkiRpAuk0Yamq2cCtwKXj7rsdOAvYsL39w6q6tZsIJUmSJHWps4QlyeoAVXUscGeSq5Js1D48FZiZZDWXLpYkSZImrk7msCRZbWzyfJKTgXcBBwIfSDIP2AY4qKoWdhGfJEmSpH4YecLSJisL2+vvBHarqtOAy5NsAawN3F1VN486NkmSJEn9MtKEZZFk5XTgacCeY49X1Y9GGY8kSZKkfhvpHJZxycq7gC2BP6+q+UkmjTIOSZIkSSuHkU+6T/IEYDNg/7FkpaoWjDoOSZIkSf038oSlqn7OuJ4VkxVJkiRJS9LJssZjJ4A0WZEkSZK0NF2f6V6SJEmSlsiERZIkSVJvdXLiSKkvkiz3c2fPnr3U57cjHyVp4IbVdtluSeoje1gkSZIk9ZYJiyRJkqTeMmGRJEmS1FsmLJIkSZJ6y4RFkiRJUm+ZsEiSJEnqLRMWaem26ToASXqEbLckrVKyqq+5nmQOcMsQXnoqcNcQXndFGNOyWdaYtgEmV9ViT1iQpID5wPcHGNsj1ZfP1zj+0LLE8cSqmra4BxZpt7p6T5a7cpa91HYLhtZ29eV/b0n6HF+fY4M/jm9Z265R6cvn15c4oD+xPNI4lly3VvWEZViSzKqqmV3HMZ4xLZs+xrS8+vJejGN4cXT1nix3YpQ9KH1/D32Or8+xgfGtbHFAf2IZZBwOCZMkSZLUWyYskiRJknrLhGX5nd11AIthTMumjzEtr768F+P4Q4OMo6v3ZLkTo+xB6ft76HN8fY4NjG9Z9SUO6E8sA4vDOSySJEmSesseFkmSJEm9ZcKiziVZ4vKbfdD3+FYGfoZL5mcjSdLSmbCoD9ZL8lBd7MMOXJLHJZkOUFXVh5gGpaP30ovvOMlTkqzeRdmLxLFS1a++xzcISdboOgZpWUyE/8fl5Wez6jJhGZEka3cdw3hJtk2yb5LHdxzH/sCXgPcneR80O3Adx/R84L+As5N8rg8xragkOyTZC0a/g9yX77hNEP4HOCbJeqMuf1wcy1W/Ov4h/pNRFNK2S1sk2WIU5Y0r99nAy7tOZscn9auqJJsm2SnJ5LH324edzLbubdd1HEuSZOpYu9XH36MefX6d16WuJXlOkmcmmdR1LOOtaPu2yjeOfZDkAOCfkmzYdSzwUDznAccB700ykp2RxcSxKfAO4I3AO4Gtk3w6yZrt4yNveJLMAP4JOAbYB5ifZN1RxzEoaWwAXAK8IckL4aGkZeiNWc++43nAz4D9gJd18b0ub/1KsgdwUpL9R32QIcnzgI8nWWeY31eSfYEvAMcCn0ny18Mqa5Fynwe8G7i2quaNosxxZb8gyVuSnJbk0VW1cJTlj1qSA4F/B04DPgIcl+RPu+5lbOvAR4EHu4phadp2+3LgnCTn9e03qS+fX5JnAWcm+eskj+owjp2SHJLkmR2UPYXm/+sdwI5JJo86hnGxDLR9M2EZsiR7Av8MXFJVdy7y2Mg//yRPAE4AXlJV+9HUge2TrDG2AzvCH45f0xzx/n5V3VxVewKTgH+Dzo4iBfhyVX0TeBywO/AvST45dvS1D0cDl1U17gEuBK4CnpXk4PaxBSMIoTffcVX9L3BOe3kxsH/7w/LUUcXActSv9uj/54D5NInO8Un+YiTBNknE3wMfqKr/G8b31SbVfwK8Gjiuql4NvBw4JckrB13eImVvDXwCeGtVXZnk0e2R7CcNs9y27J2A9wM3AOsDFyfZtd3hWOW09ftQ4KiqejbNQZQnAieOJS0dxbUXTZtwdFVdt2gvW9ftfXuA4iSa/4mXAasD70uyZZdxjenL55dk7zaOW4Djgb1GUe5i4tiX5oDw04ELkhw24hDmA99q/54CPKONa6T1eBjtmwnL8O0AnFNVlyV5bJK90gzP+dOqWthB0vI74DfAn6YZprY98HrgX4G/SjJlhD8cvwF+BcwYu6OqXgw8JsnpI4phUXOBpyV5N/A14D00vQNrA59pY+xdd/ySjGuk7gDWAX4APCPJCUmOa7cZZk9Lb77j9kjTk4AHgIOA1wFfB54wwjCWp349CXhzVZ1O0/vwPeDZw0xa2iRiOvAfwHur6ktJNm5/cHbNAOd7tEn1A8AsYN22DfoW8Bc0vUpHDKqsxVgT+DSwUZKZwPnAu4AvDrlcgK2Ay6rqgqp6Jc1BhRNp/1e6OKA1AusCf9Ze/xxN0rIm8NIuEoM0Pb07ANcDP08z5OqDSc5M8n7oRXv/a+B+4LdVNa+qXgLcA5zc/oZ3OSew88+vbavWAl4KnFRVZwBn0hyIfVbbjo1EmhEF/0yTvP0dcBjwliQbjyqG9vP+T+DNNG3K8UleA/ztkH/rFzXw9m1VbBB7YVwDMh8Y6wa7EHgF8FrgA0nWG+UQgCSTquoO4DLgX4Bv0Bw5PQD4CvBsYIMhx7BHkjckeS5N/fsUcFqSHcdt9kpGWDfbmE5I8hyaozPH0Ow8fptmZ+3eqtofWD3Jo0cV1yCM+7H4KvCLqvowzdCot9J+14PuaenLdzw+jiRPrqr5NEfTH0Wz4zQNuBaYnuRPhxzHitSvBcCRSdavqlto5r9cCczMkIaZtknEzTQ7729KsgPNzvzhNAc3js/g5wHdTnNUdK02hlk0P/h/M6wej6q6Gvg48BTgv4GLgaOAI4G3J3naMMptfQdYK8nmbSxn0PSCnpnkUava8LB2uN2ZwMFJdmvbnauA7wO7dZEYVNVcmt7eS2gOHlwH3AhcBGyX5GOjjmlRVXUfcDUwI7+fw3I8zUGOD7a3O0mq2s/vY3T4+bVt1W+BnwKvSPIMmiGeU2kOBh2bZJthx9G6H3hjVV2eZHJVfZkmmesioXx1VX0UuI3m/27tEY2qGDPw9s2EZUjGNSCXA69K8gng7Kr6C+AfaY4877ik5w9SmnHvH6JJkrZuj9S+hOaI5tfaeD8CbEjzwz2sOPamGec6Dfhzmp22G4C3t7Htn+SxwK40O2NrDSuWxcQ0FTiApqF9TFV9neZI/Dbtdi8BHk1PxziPN/Z9Jzk7v58EeQvNkf0DaYZDfQR4QpoJ8YMsuxff8SJxvIBm7PfOwE3A6cA3gb+i6Wk5ABjKMJxB1K+qOhf4Mk3isF5V3UXT8G8PDGWS69jRr6o6AbiUJrm6qKqOoWk7DgJ2GlBZacv6AO1OWJL12p6Wq2iSymEMRRt7j1+nSaqPamNY0JZ7KU2P9LDcTnNA67lJpraxnE6z03fMEMsdmTQTsXcZd9d3aBbgODzJM6pqflWdBzw+zfC8UcU1/iDCApr28EfAO6vqtKr6Gs0R+wVd9HS1vZh/k2SfJOvTHGR8EfDM9jbAEcBqbS/HqOPbM8kpSQ6hqcOfpqm3/zzqz2/cweFPANcAr6LZ1zqmvb4JMMwDDw+pqttpDgTTHiAbs2Eb6xYZ4gJM4z6LLwHXtv97e9HU72cn2XVYZS/GwNu3zibjrKqSbAus1Y5Rp6q+n+QEmqMPP2rv+2nbNTdtBPFsR7OD9npgc+Dfkrytqj6b5HJgnyQP0PxTTwNuHmI42wBnVdUZ7ZGiQ2iOaO4PnEyzI31kG8uR7VGTYVs0poNpdm4PpvmRODvJ92jGox5WVfePIKbltsj3vRnwsSRvozkivwbNkZZXVdV/JjmcJmkdpL58x4v9Xml+9E8GflVVlwMkOWTUcSxH/fpM+9y/T3JqVd2U5Ds0Bxi+OIhAk2TsQMvYcNWqWlhVJyW5pKqubB+7NsnXaHqplreszWh6+GbR9EAvaF/7kPbgzruBb6UZxrcnzQ/fCltMubTlfjPt2PuqqnZHbDtgoPUiTS/32Hu9M82qeW9rH7uiqn5Ac6S462FIKyzNanifBz6aZJ2q+u+qujvJf9G8v1OSfIbmu59Gs4Mzirj2pumZ+CxNu/RG4ISqekv+cKjjPsBjaeaMzB1FbG18+9EszHE5zUGJGVV1apq5LH9NM3xxNk37viUj3o9LM0fjn2i+2wOAdarqX9MMAfvNuE2H9vmNb6vGVNWNwBvbg3LPSbJ2Vf0syU3AU5f0vEHFMXa97RGj7WGZT7PC4vz2oNQbgOfxh5/TipT/B+1ZVS1o45ifplf8H4ADquoLaYaA3zqIcpcSz3Dbt6ryMqAL8Hya4Tb/D9hr3P1r0+yk/YzmqMiRNBXsz0YQ0/7AZ8bdfjHNkJI/p9lJehdwBc0O7dZDjuVY4MOL3Hc0zXjL9drP6dE0R6BH9Z0tLqZXtDGtTrPDORN4Ytf1azm/7wPb9/Lc9rLnuMcmr6rf8VLi+C/gce3t1Wi66tP3+tXGOZNmKOcPaH4E7gSeOsBYJy9yezVgtcVsdxjNUbInL2c5BwI/puk1+jjwGmDdRbY5Evg7mkTtaQN6f0ssd6wO0Oz8/RVNr85Aym1fd9Nx1yctUuZ2wIeAT9IcJf7X0ShWAAAa2ElEQVQp8PRh1clRXNq6/Y/AW2iGQP8L8Jxxj68HPIemZ+vjwHYjjO0E4HXj4nhF+z+149j3QjP08fvAliP+3DYDvgvMbG/vQ3O0/E/H3X5T235cAWw74vi2oOnd3a29/XrgVODJwGNH9fktpq2aNO76k4AzaPZtXk2z6MumI4pjtXHXx/6/z6QZTvvVQf5fP1w7SpMozRhRvRhJ+zayir6qXx6ugW632YFmubl3j+oHCXg8zRjdGeMq0EE0P8ibtrc3BKYOqfzHAU9or6/dlnvquMcf3VbmXUb4XS1LTP9vlDEN+ft+yfgfD9od9VXtO16GOKbSHFndtY/1iyYhediDGDS9Vi8BNhtgzPvSHHE+maanZ+z+8T/Aa9AcHfwRy7kzTzP07lP8fofnxW1b+Q5gvcVsv8aA3t8yl0vTC/eUAX62+9EcUb1g3H1jP+qrjaubT6UZRvOkYdbPUV3aej6Jpjf172mWNd97kW1WZ9zO5ojiWtxBhKNoDmZs0v7/vp8RJyttHGvRHNRcc9x9lzDuQFN7358A63cQ35rANu31acBPaHpa3tP+3RTYaJif38O1VW2dO6D93z63qzjG3T4buHfA7fXS2rNHLWb7PzrwNMBYRta+jbSyr+qXZWygh3Y0d1wZOwA70/aYtHGcRrMzO1aBTqFZzWKYR5cPohn7fnVb/jNouoivAE4bt92HgWNH9B31LqYRfd9vohlfvEp+nit7HDS9XwtpFuYY2M7yMsa8I82Ox1/SLDu7aII1PmmZRttDtZxlTaHZMTxi7LVphny9E3jluHi2b68PpH16BOVuMeDPdh2auTBH0+w8nTfuscnjrv/RTsbKeBnXFm2zyP2Ppxme8i808wkOXXSbIce1LAcRPkB7EIFmgvIoP7fHsciOHG2yTnPemr3b6zNpezJ6EN/etDvqNAc93w8cNMzPbxnaqimLbL96R3GMbzO3BaYPuPxlac9mMuQeuFG3b0N7IxPl0rcGmibr/wnNDtF/0PT4TGor02njGuTXAmcMMY71aCY2b982dsfSHFV+Kc0RmO/TTAQ7nWZS9sCGtqxMMa3M33dfPs+VPQ6ao6on0QxFOp121arFvP5ejEt6Bhj3M2iWXh+7/ViaxQneMe6+Z9KsOjOI8p5LM69p9/b2pPYzuqD9LI4HNhrC+1yWcge+MwhsTHNEfCrNEdnzFnl8G+BvaI5eD/2A1rAui7RFX6BZAW/8449v3+cVNEv1DmzI3cPE9UgOIhzXXh/Z97BIfG8DDlzk8bOArWmG+35pGP8bjyC+twIvWsJ2H6A9CDOsz+8RtFXH9ySO44b4vXTSji4mjpG1b0N9I6v6pW8NNE3WfRFwaHt7Q5rM//S2Mr+jrcyX0AzrGFoCRTMR7Erace40R7AOptmB25HmKNdfAscxoq73Psa0Mn/fffk8V4U4aMZdjw3h+yDNUqGbLrLNugxhLhXN8MGLgQ3G3bcRzVj6Q9rbTwMeP6Dy1mzbxbOBPcbdfwVDnNfXVbmLxPBoml6089rbW9MM59hwFOUP8X0t2hZNa+vPRxfZ7i3AL0fY5vfiYMYjjO+DNCvWjW3zNppk4WpGPLdpKfG9YpHtDqY5P9RQe4cfQVu1SU/iGEibuYQYOm/PFhPTUNs3VwlbTmnO1nk08A9V9Ykk02hONvbRqvprgKr6RXv/ZsBOVXX9MGOqqgfb1UPGr9KwPc0E/1Oq6pQ2nm2AG6rqF0OM5Z4kX6Y5l8HftrFcTjNcbv9qzn9w/rDKX1liWhFdf999+TxXhTiq6qZx11+V5P/RrKJ0LPBC4DdVdRHNOv+Djnt2kltpuvZ3bO+7PclZtMtxVtUPB1je3CTn06wUc3Kadfp/R7OT+8CgyulLuYvEcHeSY4B/SXIDzVCOParqzlGUPyyLaYvmpDnv0reSnFFVr2uXXF0beMGwfwvHmUSzwtx9VXVbkk8Bc2gm/N8I7EIzZ+lRND0HPxlRXA8X37OSzKmqi2mShqcDW1XVT3sU335VdUm72uQbaYaD3TjMYEbdVvU5jj60Z4uJaajtm+dhWU5V9SDwBw00TcV9epIz4KE1sYfeQOf367JD0+NzSn6/7vV8mvNQbJ/kqVU1p5rlJQeerCTZL8mpSc5qy7+A5qjViUkeU835Iz5Hs5b8RoMuf2WJaUV1+X335fNcleLIuLMPj3231ZxD4H9pjm6e2r7mMOIfW8r3WODOJFeNi3MqzblyVmvbsoGpqntplpl+J80Ja58FvKyaE9sOTVflLhLDXTQ9oevRDP/55ajKHrRlaIsOoDkx62bVOKGqvjuq+KrqHppVlN6eZMOquptmueAf0xxE+E1VnV9VZ40wiVqW+H5C06sBzWp523aQrDxcfDPazS4EnjfsHfSu2qq+xtHG0Hl7tpiYhta+mbA8Qn1roNOs2X5+ko8mOZKmW/4TwHfGxXUbzTrowzxh0QyalaC+RTN+8j00a8R/k2Y43Flp1gzfuX3K0Ne172NMK6rL77svn+eqFEeac50saK+/jebkXmMJzE9ohpU+fxg7U23Z89rrJ9MsA/o9mhN8fpJmtaJ3VnMulhp0+VU1r5pz4fwlzTl5vjfoMvpU7pj2N+T5NBOpfzDKsgfpEbRF82iGr/z/9s40Sq+qSsPPGxLCkAZEBJkEA8rQCBEEhEgio9Bq1AALacDE4ISIAyqI7XLABhREwCGCMshqAmjo4IAYyUJsQAZRICGQNIpECDJohMaIEgNv/9inyGdZlaqkvuFU1X7WuqvuPffce9871D7fPsM+bdNVQ2VGE/QdIGkL20/bbkmFxQD1HShpc9tLbf+uxZo6aqtq09FIp+1Zd1pp39SmZzokKAb6/cDjRF/1y4ATiVk7dy//yJQP9wzbc1us55XAT4n+uFsTYeO2JUI0ngC8nfgRtTHxj3RIqwyLpCOBA21PK9vHEc3Ys4l+wlOI5ve1gI+2o5atRk0DodPvu5bnOVR0lMLv+bJ+JtFCe4Bj0q8NiFmaf2R7Xgu0d7/2eNvjy/YOhLO7xPaiZl87AUlr2a6+gqQ3Om2LVqJrNyKqVldXytHEXD7PEP+LryIiZI4rOt/kMtFfO0h9q6WpCltVi47BQMvsmzswMGcwLkR88cXABCKaz+eJ2qR1iAg/dxGG+STgPtow0SAxWdNFDdtdkclmEIMgJxORImYQ/V9brWU2DXNcEEbvSlZMzjaGhvjybXo+VWkazO+7luc5FHTwj2Evv0SEqBzZuI9uITqbqLvXa+eSS3+WTtuileg6Eri4Yfs4InrVJGCrovHHlFnkO/DcUt+q6anCVtWiY7gv2cLSTySNJQYyH1u2twTeSQyon0rMHL8VEfv6DNvz26DpRcCNxCRY55W0lwHvA+6xfUVJe6FmoMnXH0cM8pLt+ySdRgwK/r7thSXPZcDDtk9p9vUHi6Zm0Yn3XcvzHKo6JJ1NzB49ydGysoZLF7FW08lrJ4ObTpc9K9E1lviBfartW0ra+4mKxvfYflrSGGC5O9DClfpWW1cVtqoWHcOVHMPSf54E9pD0IYgIYMRcF78jomPMsn0OMZFSy5wVSXtLmiJpX8eAq3cAhygidWD7oaJpYtcxLXJWDiFCOR8PfFfSoUR4yLHAWyR1Xf8XRH/+llOjpoHSyfddy/McqjrKD7zt6Iyz0rFrJ4OTWsqeHnSNk7SDpB1t/5YIhrOPImoStqcTka5OKdtL2/xjO/UNTF8VtqoWHcOaTjfx1LwAexP90Pct268muoBMacjzXuD8Nuk5EFgCfIaI9/1pIjLEAcB1wIkl3xRiAp+mzzYLiOjmci3xjwvRt/UB4AiiP/NniSbjK4GHaHHs+Bo1Deb3XcvzHA46WDGOcI0OfF8du3Yug2upoezpRdchwMPELOvziTkfxhJzrZwMTCz5Pgh8sgPPLfU1R2cVtqoWHcN1yS5hvSDpQOLHx1eIyF/fA24mWqVOAmbb/nKpXXoz8A7bz7RQj4hY57+3famknYj48WsTBcYSYobsucQMq5PcgsG6DXpOBe4HvuOIwb8H8F2i4JolaQvCwZvrqHlrOTVqWl1qeN+1PM/UkSSdowZb1IumdYn/v/Nt/0DSXkQgnE8SM7NPJVp7HicqH9/oNkVlS31J0nzSYemBGg100fVBwjk61NGXdCxwNPC87f+UtF7RaLd4IrLSr3V34EO2ny5p+wDnEDO9tj1mfI2aBkKn33ctzzN1JEln6bQtWomuqisRUl+SNI8cw9IDDi/uL8DRktZzjEmZQcyj8LpSyzCRaDLdox3OSuEywkk6StI6jv6m3wP+XdJ4R7z2x1tZYBRnDke/1nWAb0haX9Io2zcREwa1tV9njZqaREfedy3PM3UkSTV0vOzphceA/QlnCdu/AI4BPilpG9uLbf+wgz+2U1+SNIl0WHqnowa660dSN54C7iBi3k8tztQ8otVn41boKFq2k7SXpFE0fDO2jyjb5wLTJB1POHLLW6WlZk0DodPvu5bnmTqSpLN02hb1h9orEVJfkjSf7BJG/PO624OQNAI4HNgT+A1wWWkKPxf4H9tXt1jTSNvLu28rZsGeTMyevSfwI2Lyyj2LU9VsHZOB04FHyvJL4NtdXWJKnmnAZsAuwGdt39tsHbVrGiidfN+1PM/UkSSdp5aypwdd2wEbEv+Pz7shQpOkK4geELcBI4uuibYXt1pX6kuS9pAOC/UZaEX41GOJ8IKLbf9XSR9V+pmKaMI9ipiJ9nrbC1qgYxTR0vQV2z9XhHF9LbAMONP2/3XLP9r2s83WUbumgdLJ913L80wdSV9Iuhh4E/CE7Z2acL7ngK5BxA/ZntTP47YHLgF2Jebm+lIv+T4AfBjYBniJ7T+W9LcQEw8/T7TMfdj2zWXfmcAbiVa8OcR4qV4L6d6usbrUUvb0oKvqSoTUl/TGILRbLycCTr2YsAPH2F4maSpwFvH9AHzN9oXlmC8Sdgvg87a/U9L3IybaXLOc69jy2/pFwMWE3fobMM39mQ7EFYQq6+RChPW7iogxfkxD+qjyV0ST6buBDwA7tFjPHsCviQLhSKJp9vSG/SO75VcLtYwiZnSdWrZHEN1fzgTe16B311ZrqVnTYH7ftTzP1JFLP97NBKKwnd+k8y3tR55FPaRtTARfOA342EqOfTUR8noRsFFD+piu7wbYGVhY1vcGfg6sUZZbgdf3oa/Ha6zm86im7Ol2nVHAd4DxZftQ4ofTacD6PeQf3ebvMvXlsrLnP9js1neBt5f184HjyvpUwknpnv+NROXKSCLy3B3AeqXsfBh4Zcl3KuGwUL6/z5T17YmKjz7vfViPYVFExPgKcDVh8D8u6XQAR23SSAfP2P4W8HW3vjZpTeBntmc4Zgt+A3CkYkZtHN7pREkfKdstayKz/Xfgy8BkSfs4JgG7GbgbmCBpbWA88PtWa6lZ0wDp6Puu5XmmjqQvbN8I/KkxTdI2kmZL+pWkm0otYqt1PGH7DuDvfeS7y/aiHtKXNnw36wJd6wbWImzCaOKH5uMAkg6SdKukOyXNVMw23us1VpNqyp4eWI8YPwNRXl9DPJ8jIcpySbuW/cvaqKuL1Jf0yGCyW6UFdT+iEh/gUuCtfZx6R+BG28tt/4Wo6DiYaKFZZvv+km8O4Sx3HfPTomshsLWkTfq6h2HtsFCngf4rsImkDcs1HyUmqTtE0hElzx+BmW3QAnATMbDyGEkTbD9n+3Ki6Xgz2+fYfqxNWmrWtLrU8L5reZ6pI1lVvgmcYHs34GPA9FU4di1Jv5R0m6S+CuWmIultkhYS3YynAdi+lZh89NGy/MT2AkkbAZ8CDrC9K9Gd58QWyKrBFv0TtVcipL5kNajVbr0YeMorhkgsBjZv2H+opHmSrpK0ZUmbCxwsaZ1iq/YFtiRsxUhJryn5DivpXcdMhhcaDrYCtuhL3MjVv68hwQsG2vafbD+qmDzpWknzHP3w2mqgbf9K0mJgNtFEj+3HJH2dEo3FbexbavtvkmYQtX+nlJqAZ4GXAEvbpaN2TatLDe+7lueZOpJVobQy7A3M1IrAVqPLvslEF4TuPGL7DWV9K9uPKOYU+amke2w/UP73xpc8m0m6u6zPtH1aM7Q7grZcLWkCMZ7lAEnbAjuwouCeo5jnZ32iRvLn5T7XJLqLNZUabNFKuAnYjqhEUKm1vlzSeyiVCB3S1UXqS/rFILZbPwSusP2spPcSrS/72b5O0u7ALcAfCNv0nG1LejtwjqTRRCVgV6CHLwDnFY33AHfRj6h0w9phqc1AS1rT9jLb75d0jaSbgcNKbe5GwI6K6GVuZy2I7SclfQu4D3gvMUjqaNuPt0vDYNC0qtT0vmt5nqkjWQVGELWB47rvsD0LmLWyg20/Uv7+VtLPiPEgD9g+viuPpEU9nb9Z2L5R0thSM/k24DbbS8u1f0y0cCwA5tg+slU6arJFPVF7JULqS1aBmu3WEmADrQhEtQVlkL3tJQ35LiTGdXZpOo0YG4Oky4nJSLtajfcp6QcBryzpTwPvLOkCHgT6DGQ1bB2W2gy0pBG2l5X1U4CziSaz6ZKWEZE7DivNuW2naLtB0o2x2RkdtWvqLzW+71qeZ+pI+oMjzPyDkg63PbMUfDvbntvXsYooNc+U2sKNiJrJM/s4rCmUlpQHSg3krkTt6hLgIeDdks4ggr1MJOb7uQ34uqRtbf9G0rrA5l7RN3ygeqqzRT1ReyVC6kv6Q812q9ikG4juW1cCU4Dvl2tv6ugmCjCJqEhBEU13A9tLJO1MBBK5ruzb2PYTpYXlZFY4NRuU+1gGvIsYA/NCxLreGJZhjYuBfr6sn0IUCJOJvnqNBrotrSvd9JxJRPMYX7Z3IKKULXHzBlcmHSTfd5KsOoq5Il5PVCg9DnyGGLj5DWBTYhDxlbZ76lLR/Vx7AxcQoYVHAOfavqiHfItsb90t7aXEOJL1yvFLgR3LD5FrgXfZ/r2kDwInAS8FngCutf0uSScD7yAGv/4V+Ljtm0vBP52IKmRgtu0TyzX3A75I6ToCfMr2D3q7Rl/333Avg9IWlWdVbSVC6ku6GIR2ayzhrGxIdNU6ujhIZxCOynIiiMBxthdKWgu4s1zmaSKa5t3lmmcRIZ1HAN+wfW5J34voUmbgXiJ62JN93v9wc1hqM9Dd9HwJ+FfgzW6YFyYZOuT7TpKkBtIWJUkymBhWDkvNBlrS2cSAy0kuk1a6YSbaZGiR7ztJkhpIW5QkyWBgWIU1bnBWziairrzZK2a07xiSXkZE8MgCYxiQ7ztJkhpIW5QkyWBhWLWwwAsGejrw1poMtCSVAU9V6ElaS77vJElqIG1RkiSDgWHnsEAa6CRJkiRJkiQZLAxLhyVJkiRJkiRJksHBsBrDkiRJkiRJkiTJ4CIdliRJkiRJkiRJqiUdliRJkiRJkiRJqiUdliRJkiRJkiRJqiUdlqRjSDpc0r2Snpf0ml7ybCnpBkn3lbwfati3oaQ5kn5d/r6opB8laZ6keyTdImmXfmg5TdLDkpY27w6TWpB0lqSF5bu4WtIGveTbQNJVJe8CSXs14dqzJT0l6ZqBnitJkqFLP8vEtST9QtLckvdzDfsuKunzih0bU9InSLpT0nJJh/VTy8WSnpA0vzl3lyQDIx2WpC1Ier2kb3dLng9MBm5cyaHLgY/a3hF4LXC8pB3Lvk8A19t+BXB92QZ4EJho+1XA54Fv9kPiD4E9+nMvSd308q3NAXayvTNwP3BKL4efB8y2vT2wC7CgCZLOAo5pwnmSJBkiDKBMfBbYz/YuwDjgYEmvLfs+YnuXYuceAj5Q0h8CpgKXr4LEbwMHr0L+JGkp6bAkHcP2Atv/20eeR23fWdb/TPyA3LzsfgtwaVm/FHhryXeL7SdL+m3AFl3nk3R0qZ26W9IFktYox9xm+9Fm3VtSF7avs728bP7DN9GFpPWBCcBF5Zhltp8q+7YpLSW/knSTpO1X4drXA38e8E0kSTKk6WeZaNtdPQFGlcVl39MQc80BazekL7I9D3i++/kkfVzSHaVV5oXWGts3An9qwm0lSVNIhyUZNEjaGng1cHtJ2qTByXgM2KSHw44FflyO3wE4AhhvexzwHHBUCyUndTKN8k104+XAH4BLJN0l6UJJ65Z93wROsL0b8DFgenukJkmS/COS1pB0N/AEMMf27Q37LiHKw+2Br/ZxnoOAVxC9C8YBu0ma0DLhSTIARnZaQDK0kXQ7MBoYA2xYjCzAybZ/sgrnGQP8N/DhrlqkRmxbkrsdsy/hsLyuJO0P7AbcERVQrE0Y/GQI0J9vTdJ/EN0MZ/RwipHAroRjcruk84BPSPoisDcws3w3lOsgaTJwag/nesT2G5pzZ0mSDBWaUSbafg4YV8biXS1pJ9vzy753lp4DXyUq6C5ZyakOKstdZXsM4cCsrEtaknSEdFiSlmJ7T4j+usBU21NX9RySRhHOygzbsxp2PS5pU9uPStqUBudD0s7AhcAhtpd0JQOX2u5t/EIyiOnrW5M0FXgTsL9tdz8eWAwsbqitvIoYFzUCeKq0ynW/5ixgVvf0JEmSnmhGmdhwrqck3UCMNZnfkP6cpCuBk1i5wyLgDNsXrK6GJGkX2SUsqZrSF/ciYIHtL3fb/QNgSlmfAny/HPMy4kfkMbbvb8h/PXCYpI1Lvg0lbdVK/UkdSDqYKLwn2X6mpzy2HwMelrRdSdofuK+06D0o6fByLvUn8lySJEmzkfSSriiHktYGDgQWFru0bUkXMAlY2MfpfgJMa4gmtnlX+ZgktZEOS9IxJL1N0mJgL+BHkrq67Wwm6dqSbTwRYWm/MlD+bkn/VvZ9AThQ0q+BA8o2wKeBFwPTS/5fAti+D/gUcJ2keUTkqE3LNc8sWtaRtFjSZ1t790mb+RrwL8Cc8k2cD//0rQGcAMwo38c44PSSfhRwrKS5wL1EwId+IekmYCawf/m2sqtYkiT/RD/LxE2BG4qNuoMYw3INpQeBpHuAe0q+U8vxu5fzHg5cIOleiGAkROSwW8txVxF2EklXALcC2xW7dWwbHkGS9Ip67hmRJEmSJEmSJEnSebKFJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSakmHJUmSJEmSJEmSavl/U066cwU5mTYAAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 849.6x849.6 with 25 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "gV6nyqcHjoDz"
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
This PR should greatly speed up the cic painting step, because there is an annoying quirk in tensorflow, which caused our baseline implementation to send stuff back and forth between CPU and GPU. This fixes it.

This should speed things up anywhere from x2 to x10 dependending on the problem.

I also added a notebook where I propose to optimize the way we do the sampling, with 2 mass bins, so that we can use only a restricted number of max_sat for low mass halos without causing problems for large mass halos.
